### PR TITLE
Implement fmql-semantic hybrid-retrieval backend

### DIFF
--- a/docs/fmql-semantic.md
+++ b/docs/fmql-semantic.md
@@ -1,360 +1,172 @@
-# fmql-semantic — Implementation Spec
+# fmql-semantic — Spec
 
-**hybrid vector search with bm25 reranker in sqlite RRF**
+Hybrid retrieval plugin for fmql: dense (embeddings) + sparse (BM25), fused with RRF, with optional cross-encoder reranking. Separate pip-installable package. Registers via `fmql.search_index` entry point.
 
-Ship semantic search for fmql as a separate pip-installable package that registers itself via the `fmql.search_index` entry point. Uses LiteLLM as the embedding provider abstraction and `sqlite-vec` as the local vector store. Delivered as the first reference implementation of a third-party fmql plugin.
+## Dependencies
 
-## Non-goals
-
-- Bundling specific embedding models. Users configure providers via LiteLLM.
-- Hybrid retrieval (semantic + keyword). Users can compose with fmql's existing filter DSL by piping.
-- Reranking with cross-encoders or LLM rerankers. Out of scope for v0.1.
-- Remote vector stores (Pinecone, Qdrant Cloud, etc.). Local-only. If there's demand, ship as separate plugins (`fmql-qdrant`, etc.).
-- Embedding frontmatter field values specifically. Frontmatter is already queryable via fmql's structured layer — embedding it is semantic overlap. Body text is the interesting target.
-
-## Design principles
-
-1. **LiteLLM is the only embedding abstraction.** Any provider LiteLLM supports (OpenAI, Voyage, Cohere, Anthropic, Ollama, Azure, Bedrock, etc.) works. No per-provider adapters in this package.
-2. **sqlite-vec is the only store.** One file on disk, no daemon, no network, travels with the workspace. Good enough for workspaces up to ~100k packets. Users with bigger needs are outside this plugin's scope.
-3. **Configuration via environment, not flags.** Embedding provider config lives in the user's environment (standard LiteLLM convention). fmql-semantic reads it, never writes it, never proxies API keys through CLI flags.
-4. **Incremental by default.** Re-indexing an unchanged workspace must be near-instant. Content-hash-based skip, hash stored in the index.
-5. **Fail loud, fail early.** Missing config or provider errors produce clear, actionable messages — not LiteLLM stack traces.
-6. **One model per index.** An index is pinned to the embedding model that built it. Switching models requires a fresh build. No attempt to mix dimensionalities.
-
-## Architecture
-
-```
-    workspace (directory of frontmatter .md)
-             │
-             ▼
-    ┌──────────────────┐
-    │ fmql core        │  Packet iteration, filters, hash computation
-    └────────┬─────────┘
-             │
-             ▼
-    ┌──────────────────┐
-    │ fmql-semantic    │  Batching, incrementality, sqlite-vec I/O
-    └────────┬─────────┘
-             │
-             ▼
-    ┌──────────────────┐
-    │ LiteLLM          │  Provider routing, retries, standard interface
-    └────────┬─────────┘
-             │
-             ▼
-    embedding provider (OpenAI / Voyage / Ollama / ...)
-```
-
-fmql-semantic does not talk to providers directly. All embedding calls go through `litellm.embedding()`.
+- `fmql>=0.2` (plugin protocol)
+- `litellm` (embeddings and reranking)
+- `sqlite-vec` (dense vector storage; BM25 via SQLite's built-in FTS5)
 
 ## Configuration
 
-Read from environment at runtime. No config file.
+All options configurable via environment variables, dotenv file (`--env PATH`), or CLI flags. Precedence: flags > dotenv > process env > defaults.
 
-| Variable | Required | Default | Meaning |
+### Env vars
+
+| Variable | Required | Default | Purpose |
 |---|---|---|---|
-| `FMQL_EMBEDDING_MODEL` | yes | — | LiteLLM model string, e.g. `openai/text-embedding-3-small`, `voyage/voyage-3`, `ollama/nomic-embed-text`. |
-| `FMQL_EMBEDDING_DIMENSIONS` | no | provider default | Override output dimensions if the provider supports it (e.g. OpenAI v3 models support truncation). |
-| `FMQL_EMBEDDING_BATCH_SIZE` | no | `100` | Packets per embedding API call. |
-| `FMQL_EMBEDDING_MAX_TOKENS` | no | `8000` | Truncate packet content to this many tokens before embedding. |
-| `FMQL_EMBEDDING_CONCURRENCY` | no | `4` | Max concurrent embedding requests during a build. |
+| `FMQL_EMBEDDING_MODEL` | yes | — | LiteLLM embedding model string. |
+| `FMQL_EMBEDDING_API_BASE` | no | provider default | Override API base URL. |
+| `FMQL_EMBEDDING_API_KEY` | no | provider default | Override API key. |
+| `FMQL_EMBEDDING_BATCH_SIZE` | no | 100 | Packets per embedding call. |
+| `FMQL_EMBEDDING_CONCURRENCY` | no | 4 | Max concurrent embedding requests. |
+| `FMQL_EMBEDDING_MAX_TOKENS` | no | 8000 | Per-packet truncation before embedding. |
+| `FMQL_RERANKER_MODEL` | no | unset | LiteLLM rerank model. Setting this enables reranking by default. |
+| `FMQL_RERANKER_TOP_N` | no | 50 | Candidates sent to reranker. |
 
-Plus any standard LiteLLM variables for the chosen provider (`OPENAI_API_KEY`, `VOYAGE_API_KEY`, `OLLAMA_API_BASE`, etc.). fmql-semantic does not read or validate these — LiteLLM handles it.
+Standard LiteLLM provider env vars (`OPENAI_API_KEY`, `VOYAGE_API_KEY`, `OLLAMA_API_BASE`, etc.) are read by LiteLLM directly.
 
-Backend-specific options passable via `fmql index --option KEY=VALUE` override environment values for a single run:
+## CLI surface
 
-```bash
-fmql index ./board --backend semantic \
-  --option model=voyage/voyage-3 \
-  --option batch_size=50
-```
-
-## What gets embedded
-
-For each packet, the embedded text is:
+### `fmql index WORKSPACE` (semantic backend)
 
 ```
-<title field>
+--backend semantic
+--out LOCATION            Default: <workspace>/.fmql/semantic.db
+--force                   Rebuild from scratch.
+--filter QUERY            Restrict indexing to packets matching this filter.
+--fields FIELD[,FIELD...] Fields to index. Default: title/summary/name + body.
+
+--model MODEL
+--api-base URL
+--api-key KEY
+--batch-size INT
+--concurrency INT
+--max-tokens INT
+
+--env PATH                Load env vars from dotenv file.
+--format {text,json}      Stats output format.
+--option KEY=VALUE        Escape hatch for uncommon options.
+```
+
+### `fmql search QUERY`
+
+```
+--backend semantic
+--workspace PATH
+--index LOCATION
+-k INT                    Max results. Default: 10.
+
+--rerank                  Enable reranking. Default if reranker model is configured.
+--no-rerank               Disable reranking for this query.
+--dense-only              Skip BM25 and fusion.
+--sparse-only             Skip embeddings and fusion.
+
+--model MODEL
+--reranker-model MODEL
+--api-base URL
+--api-key KEY
+
+--env PATH
+--format {paths,json,rows}
+--option KEY=VALUE
+```
+
+## Indexing
+
+For each packet, index the same text into both dense and sparse stores:
+
+```
+<first present frontmatter field from --fields list>
 
 <body>
 ```
 
-Where `<title field>` is the first present frontmatter field from a configurable list (default: `title`, `summary`, `name`). Frontmatter itself is not embedded — it's already structurally queryable.
+Frontmatter field values themselves are not indexed — they're already queryable via fmql's structured layer.
 
-Overridable via `--option` or via a `text_fields` option passed to `build()`:
+Text exceeding `max_tokens` is truncated from the end with a single warning per build.
 
-```bash
-fmql index ./board --backend semantic --option text_fields=title,summary,body
-```
+### Build requirements
 
-If the resulting text exceeds `FMQL_EMBEDDING_MAX_TOKENS`, it is truncated from the end with a warning logged once per build.
+- Incremental: skip packets whose content hash is unchanged since last build.
+- Packets removed from the workspace are removed from the index.
+- Partial builds (crash mid-run) leave a valid, queryable index; re-running picks up where it left off.
+- Progress bar on TTY, suppressed otherwise.
+- Final write is atomic (write to temp file, rename on success).
+
+### Model pinning
+
+An index is pinned to the embedding model that built it. Building against an existing index with a different model refuses unless `--force` is passed. Error message names both models and the rebuild command.
+
+## Querying
+
+Default mode: hybrid.
+
+1. **Dense retrieval**: embed the query, cosine search in `sqlite-vec`, return top `fetch_k`.
+2. **Sparse retrieval**: tokenise the query, BM25 search in FTS5, return top `fetch_k`.
+3. **RRF fusion**: combine the two ranked lists, `k_rrf = 60`.
+4. **Rerank (optional)**: if reranker is configured, send top `rerank_top_n` fused candidates through LiteLLM rerank, re-sort by rerank score.
+5. Truncate to `k`, return.
+
+Defaults: `fetch_k = max(k * 4, 50)` per retriever, `rerank_top_n = 50`.
+
+### Mode overrides
+
+- `--dense-only`: skip sparse retrieval and fusion.
+- `--sparse-only`: skip dense retrieval, fusion, and any embedding API call.
+- `--no-rerank`: skip reranking even if globally configured.
+
+### Score semantics
+
+Returned `SearchHit.score` is whichever ranker produced the final order: reranker score if rerank ran, RRF score otherwise, cosine similarity if dense-only, BM25 score if sparse-only. Scale differs across modes; use for ranking, not thresholding.
+
+### Reranker fallback
+
+If reranking is enabled but the provider call fails, log a warning and return RRF-sorted results. `--option rerank_required=true` changes this to hard fail.
 
 ## Index format
 
-A single SQLite file at the user-specified output path (default: `<workspace>/.fmql/semantic.db`).
+Single SQLite file. Contains:
 
-Schema:
+- `meta` table: backend version, fmql version, built_at, embedding model, embedding dimensions, indexed fields, format_version.
+- `packets` table: packet id, content hash, indexed_at.
+- `vectors`: sqlite-vec virtual table, `float[<dimensions>]`.
+- `packet_vectors`: packet_id ↔ rowid mapping.
+- `packets_fts`: FTS5 virtual table, tokenizer `unicode61 remove_diacritics 2`, same rowids as `vectors`.
 
-```sql
--- Metadata table: one row, describes the index.
-CREATE TABLE IF NOT EXISTS meta (
-    key   TEXT PRIMARY KEY,
-    value TEXT NOT NULL
-);
--- Populated keys:
---   backend            = 'semantic'
---   backend_version    = e.g. '0.1.0'
---   fmql_version       = e.g. '0.2.0'
---   built_at           = ISO timestamp of most recent build
---   model              = e.g. 'openai/text-embedding-3-small'
---   dimensions         = e.g. '1536'
---   text_fields        = JSON array, e.g. '["title","body"]'
---   format_version     = '1'
-
--- Packet registry: stable ids + content hashes for incrementality.
-CREATE TABLE IF NOT EXISTS packets (
-    id            TEXT PRIMARY KEY,     -- workspace-relative id
-    content_hash  TEXT NOT NULL,        -- sha256 of embedded text
-    token_count   INTEGER NOT NULL,
-    indexed_at    TEXT NOT NULL         -- ISO timestamp
-);
-
--- Vectors: sqlite-vec virtual table. Rowid joins to packets via order-of-insertion
--- — we maintain a separate mapping since sqlite-vec rowids are opaque.
-CREATE VIRTUAL TABLE IF NOT EXISTS vectors USING vec0(
-    embedding float[<dimensions>]
-);
-
--- Rowid <-> packet id mapping. sqlite-vec rowids are stable within a DB.
-CREATE TABLE IF NOT EXISTS packet_vectors (
-    packet_id  TEXT PRIMARY KEY REFERENCES packets(id) ON DELETE CASCADE,
-    rowid      INTEGER NOT NULL UNIQUE
-);
-```
-
-**Format version.** `format_version = '1'` today. Bumped on any schema change. Loading an index with a different format version raises `IndexVersionError` and instructs the user to rebuild with `--force`.
-
-**Model pinning.** The `model` and `dimensions` meta values are set at first build. Subsequent builds that detect a mismatch refuse to proceed unless `--force` is set. Users switching models must rebuild.
-
-## Build algorithm
-
-```python
-def build(packets, out_path, options=None):
-    cfg = resolve_config(options)
-    db = open_or_create(out_path, cfg)
-    check_model_compatibility(db, cfg)  # raises if model changed
-
-    existing_hashes = load_existing_hashes(db)
-    to_embed = []
-    seen_ids = set()
-
-    for packet in packets:
-        text = render_embedding_text(packet, cfg.text_fields)
-        h = sha256(text)
-        seen_ids.add(packet.id)
-        if existing_hashes.get(packet.id) != h:
-            to_embed.append((packet.id, text, h))
-
-    # Remove packets that disappeared from the workspace.
-    removed = set(existing_hashes) - seen_ids
-    delete_packets(db, removed)
-
-    # Embed in batches, with bounded concurrency.
-    stats = embed_and_store(db, to_embed, cfg)
-
-    update_meta(db, built_at=now_iso())
-    return IndexStats(
-        packets_indexed=stats.indexed,
-        packets_skipped=len(seen_ids) - len(to_embed),
-        packets_removed=len(removed),
-        elapsed_seconds=stats.elapsed,
-    )
-```
-
-**Batching.** Batches of `FMQL_EMBEDDING_BATCH_SIZE` packets per LiteLLM call. Providers reject requests over their input limit — on a 4xx "too many tokens" response, halve the batch and retry. On persistent failure at batch size 1, skip the packet and log.
-
-**Concurrency.** Up to `FMQL_EMBEDDING_CONCURRENCY` batches in flight via `asyncio.Semaphore`. LiteLLM has async support (`litellm.aembedding`). Use it.
-
-**Retries.** LiteLLM handles provider-level retries. fmql-semantic adds one layer of retry (default: 3 attempts, exponential backoff) for transient network failures surfaced as exceptions.
-
-**Progress reporting.** A `tqdm` progress bar during builds when stdout is a TTY, suppressed otherwise. Granularity: per batch.
-
-**Transactionality.** Each successfully-embedded batch is written to the sqlite file in a single transaction. Partial builds leave a valid, queryable index covering whatever was embedded before the interruption. Re-running `fmql index` picks up where it left off via the content-hash skip.
-
-## Query algorithm
-
-```python
-def query(text, index_path, k=10, options=None):
-    cfg = resolve_config(options)
-    db = open_readonly(index_path)
-    meta = load_meta(db)
-
-    # Query-time model must match index-time model.
-    if cfg.model != meta['model']:
-        warn(f"Query model {cfg.model!r} differs from index model "
-             f"{meta['model']!r}. Using index model for query.")
-        cfg = cfg.with_model(meta['model'])
-
-    query_vec = litellm.embedding(model=cfg.model, input=[text]).data[0].embedding
-
-    rows = db.execute("""
-        SELECT pv.packet_id, vec_distance_cosine(v.embedding, ?) AS distance
-        FROM vectors v
-        JOIN packet_vectors pv ON pv.rowid = v.rowid
-        ORDER BY distance
-        LIMIT ?
-    """, (serialize(query_vec), k)).fetchall()
-
-    return [SearchHit(packet_id=pid, score=1.0 - dist, snippet=None) for pid, dist in rows]
-```
-
-Score is `1 - cosine_distance`, normalised to `[0, 1]` where higher is better. This matches the `SearchIndex` protocol convention.
-
-Snippets are not produced in v0.1. Callers that want context can read the packet body themselves from the returned id.
+`format_version = 1` at first release. Mismatched format version raises `IndexVersionError` with rebuild instructions.
 
 ## Error handling
 
-Beyond the standard errors from `fmql.search.errors`:
+- Missing `FMQL_EMBEDDING_MODEL` and no `--model`: clear error listing example model strings and the LiteLLM docs URL.
+- Provider errors: re-raised as `BackendUnavailableError` with provider error type in the message. Full trace only with `FMQL_DEBUG=1`.
+- Model mismatch on existing index: error names both models, suggests `--force`.
+- Missing `--env` file: hard error.
 
-**Missing configuration.** If `FMQL_EMBEDDING_MODEL` is not set and no `--option model=...` is passed:
+## Testing
 
-```
-error: fmql-semantic requires an embedding model to be configured.
-
-Set FMQL_EMBEDDING_MODEL to a LiteLLM-supported model identifier, e.g.:
-
-    export FMQL_EMBEDDING_MODEL=openai/text-embedding-3-small
-    export FMQL_EMBEDDING_MODEL=ollama/nomic-embed-text
-    export FMQL_EMBEDDING_MODEL=voyage/voyage-3
-
-Or pass --option model=<id> on the command line.
-
-See https://docs.litellm.ai/docs/embedding/supported_embedding for the
-full list of supported models.
-```
-
-**Provider errors.** LiteLLM raises provider-specific exceptions (rate limits, auth failures, etc.). Caught once and re-raised as `BackendUnavailableError` with a short message including the original provider error type. Full trace only with `FMQL_DEBUG=1`.
-
-**Model mismatch.** If an existing index was built with a different model than the one currently configured, `build()` without `--force` raises:
-
-```
-error: This index was built with model 'openai/text-embedding-3-small'
-(1536 dimensions). You're trying to build with 'voyage/voyage-3'
-(1024 dimensions). These are incompatible.
-
-To rebuild from scratch with the new model:
-    fmql index WORKSPACE --backend semantic --force
-```
-
-## Testing strategy
-
-**Unit tests:**
-- `render_embedding_text` produces expected text for various frontmatter shapes.
-- Content hashing is stable across runs.
-- Schema creation + migration between format versions.
-- Model-mismatch detection.
-
-**Integration tests with a fake provider:**
-- Register a local LiteLLM custom provider that returns deterministic fake embeddings (e.g. hash-based). Use it for all integration tests. No real API calls in CI.
-- End-to-end: build, query, incremental build (verify skip count), rebuild after deletion (verify removal), concurrent build cancellation leaves a valid index.
-
-**Conformance tests:**
-- Import `fmql.search.conformance` and run the protocol conformance suite. Must pass.
-
-**Live provider smoke test:**
-- A separate `tests/live/` directory with tests gated behind `FMQL_LIVE_TESTS=1`. Runs against a real provider (configurable). Not part of CI by default; used as a pre-release smoke check.
-
-**Coverage target:** ≥85% (matches fmql core).
-
-## Performance expectations
-
-Rough numbers to validate against during development. These are goals, not guarantees.
-
-| Workspace size | Cold build time (OpenAI) | Warm rebuild (no changes) | Query latency |
-|---|---|---|---|
-| 100 packets | < 5s | < 50ms | < 200ms |
-| 1,000 packets | < 30s | < 500ms | < 300ms |
-| 10,000 packets | < 5min | < 3s | < 500ms |
-| 100,000 packets | "it works" | < 30s | < 2s |
-
-The 100k number is a soft ceiling. sqlite-vec can handle it but query latency degrades linearly without an ANN index. If users push past this, they're on the boundary of what this plugin targets.
+- Fake embedding provider and fake reranker registered as LiteLLM custom providers for all integration tests. No real API calls in CI.
+- Conformance suite from `fmql.search.conformance` passes.
+- RRF correctness: fixed inputs produce hand-computed outputs.
+- Mode correctness: `--dense-only`, `--sparse-only`, hybrid, hybrid+rerank each produce expected behaviour.
+- Fallback correctness: reranker failure soft-falls-back to RRF; `rerank_required=true` hard-fails.
+- Live smoke tests gated behind `FMQL_LIVE_TESTS=1`, not in CI.
+- Coverage target: ≥90%.
 
 ## Packaging
 
-```toml
-# pyproject.toml
-[project]
-name = "fmql-semantic"
-version = "0.1.0"
-description = "Semantic search backend for fmql, using LiteLLM + sqlite-vec"
-requires-python = ">=3.11"
-dependencies = [
-    "fmql>=0.2",
-    "litellm>=1.40",
-    "sqlite-vec>=0.1",
-    "numpy>=1.26",
-]
+- Name: `fmql-semantic`.
+- Python: 3.11+.
+- Pure Python; no platform-specific wheels.
+- Entry point: `fmql.search_index` → `semantic = "fmql_semantic:SemanticBackend"`.
 
-[project.optional-dependencies]
-dev = ["pytest", "pytest-asyncio", "pytest-cov", "ruff", "black"]
 
-[project.entry-points."fmql.search_index"]
-semantic = "fmql_semantic:SemanticIndex"
-```
+## Deliverables
 
-**Version pinning.** `fmql>=0.2` because that's when the plugin protocol landed. `litellm>=1.40` for stable `aembedding`. `sqlite-vec>=0.1` — note this is still pre-1.0, so pin upper bound once a 1.0 ships.
-
-**Supported Python versions.** 3.11+, matching fmql core.
-
-**Wheels.** Pure Python package; no platform-specific wheels needed. sqlite-vec ships its own wheels.
-
-## Documentation deliverables
-
-1. **README.md** — what it is, one-paragraph install, 5-line usage example, link to full docs.
-2. **docs/configuration.md** — every env var, every `--option`, provider setup walkthroughs for 3-4 common providers (OpenAI, Voyage, Ollama, Azure).
-3. **docs/cookbook.md** — common patterns: combining semantic + structural filters, per-project indexes, incremental workflows.
-4. **docs/troubleshooting.md** — common errors and fixes. Model mismatch, rate limits, missing keys, index corruption.
-5. **Blog post** — "Adding semantic search to fmql as a plugin." Covers both the why (why separate package) and the how (LiteLLM as abstraction, sqlite-vec as store, plugin protocol in practice). Serves as the second launch moment.
-
-## Implementation checklist
-
-Phase 1 — core mechanics (1 day):
-
-1. Package skeleton, `pyproject.toml`, entry point.
-2. Config resolution from env + options.
-3. SQLite schema + migration scaffolding.
-4. `render_embedding_text` and content hashing.
-5. Synchronous build path with LiteLLM (no batching yet).
-6. Query path.
-
-Phase 2 — production readiness (1 day):
-
-7. Batching with adaptive batch-size on 4xx.
-8. Async/concurrent builds.
-9. Incrementality: hash-based skip, packet deletion.
-10. Progress reporting.
-11. Full error handling + friendly messages.
-
-Phase 3 — tests and docs (1 day):
-
-12. Fake-provider test harness.
-13. Unit + integration tests.
-14. Conformance suite integration.
-15. README, configuration docs, cookbook, troubleshooting.
-16. Live smoke test harness.
-
-Phase 4 — release (half day):
-
-17. Tag v0.1.0, publish to PyPI.
-18. Announcement blog post.
-19. Add to fmql core README's "known plugins" list.
-
-Total: ~3.5 days of focused work.
-
-## Open questions
-
-- Should fmql-semantic support per-field embeddings (separate vectors for title, body, notes)? Useful for weighted hybrid queries. Deferred — single concatenated text for v0.1, revisit if users ask.
-- Should the index support multiple models side-by-side (different vector tables per model)? Cleaner than the current "one model per index" rule but significant complexity. Deferred to v0.2.
-- Should there be a `fmql-semantic migrate-model` command that reads an old index, re-embeds with a new model, and writes a new index? Probably yes eventually. Not v0.1.
-- sqlite-vec's ANN support is evolving. v0.1 uses linear scan (fine up to ~100k). Add ANN indexing when sqlite-vec's story there is stable.
-- Should builds write to a temp file and atomically rename on success, to avoid leaving a corrupt index on crash? Yes — add to Phase 2.
+- Package source + tests.
+- README (shipped to PyPI).
+- Configuration docs covering every env var and flag.
+- Provider setup walkthroughs: OpenAI, Voyage, Ollama, Azure.
+- Troubleshooting guide: model mismatch, rate limits, missing keys, corrupted index.
+- Announcement blog post.

--- a/packages/fmql-semantic/CHANGELOG.md
+++ b/packages/fmql-semantic/CHANGELOG.md
@@ -4,4 +4,16 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
-- Initial package slot reserved in the monorepo. No functional code yet.
+### Added
+
+- Hybrid-retrieval `semantic` backend registered via the `fmql.search_index` entry point.
+- Dense embeddings through LiteLLM (`litellm.aembedding`) stored in `sqlite-vec` virtual tables with DDL-pinned dimensions.
+- Sparse BM25 retrieval via SQLite FTS5 (`unicode61 remove_diacritics 2` tokenizer).
+- Reciprocal Rank Fusion (k=60) combining dense + sparse rankings.
+- Optional cross-encoder reranking via `litellm.arerank` with soft-fail fallback to RRF.
+- Query modes: hybrid (default), `dense_only`, `sparse_only`, `no_rerank`.
+- Incremental indexing keyed on content hash; deletions reconciled on rebuild.
+- Model pinning in index metadata; mismatches refuse to build without `--force`.
+- Format-version gate (`FORMAT_VERSION = 1`) raises `IndexVersionError` on incompatible indexes.
+- Config resolution: `--option KEY=VALUE` > dotenv (`--option env=path`) > `FMQL_*` env > defaults.
+- Optional `progress` extra adds `tqdm` progress bars.

--- a/packages/fmql-semantic/README.md
+++ b/packages/fmql-semantic/README.md
@@ -1,9 +1,113 @@
 # fmql-semantic
 
-Semantic (embedding-based) search backend plugin for [`fmql`](https://pypi.org/project/fmql/).
+Hybrid semantic search backend plugin for [`fmql`](https://pypi.org/project/fmql/).
 
-**Status: pre-alpha stub.** No usable code yet. The package slot is reserved so
-plugin development can happen alongside `fmql` core in the same repo. Design
-notes live in [../../docs/fmql-semantic.md](../../docs/fmql-semantic.md).
+- **Dense** retrieval via LiteLLM embeddings + [`sqlite-vec`](https://github.com/asg017/sqlite-vec).
+- **Sparse** retrieval via SQLite FTS5 (BM25).
+- **Fusion** via reciprocal rank fusion (RRF).
+- **Optional reranking** via LiteLLM rerank providers (Cohere, Voyage, etc.).
+- Single-file SQLite index. No server.
 
-Do not install this package — it does nothing.
+## Install
+
+```sh
+pip install fmql-semantic
+```
+
+`fmql-semantic` requires a Python build with `sqlite3` loadable-extension support
+(macOS/Linux/Windows builds from python.org, `pyenv`, `uv`, and official Docker
+images all qualify; the macOS system Python at `/usr/bin/python3` does not). If
+the extension loader is unavailable, the backend fails fast with a clear error.
+
+## Configure
+
+`fmql-semantic` reads configuration from three channels, in increasing
+precedence:
+
+1. Process environment.
+2. A dotenv file pointed to by `--option env=path/to/.env`.
+3. `--option KEY=VALUE` flags on the command line.
+
+### Environment variables
+
+| Variable | Purpose |
+|---|---|
+| `FMQL_EMBEDDING_MODEL` | LiteLLM embedding model string (required). |
+| `FMQL_EMBEDDING_API_BASE` | Override provider API base URL. |
+| `FMQL_EMBEDDING_API_KEY` | Override provider API key. |
+| `FMQL_EMBEDDING_BATCH_SIZE` | Packets per embedding call (default 100). |
+| `FMQL_EMBEDDING_CONCURRENCY` | Max concurrent embedding requests (default 4). |
+| `FMQL_EMBEDDING_MAX_TOKENS` | Per-packet token budget before truncation (default 8000). |
+| `FMQL_RERANKER_MODEL` | LiteLLM rerank model. Enables reranking when set. |
+| `FMQL_RERANKER_TOP_N` | Candidates sent to reranker (default 50). |
+
+Standard LiteLLM provider env vars (`OPENAI_API_KEY`, `VOYAGE_API_KEY`,
+`OLLAMA_API_BASE`, …) are read by LiteLLM directly.
+
+### `--option` keys
+
+Build: `model`, `api_base`, `api_key`, `batch_size`, `concurrency`,
+`max_tokens`, `fields`, `force`, `env`.
+
+Query: `model`, `api_base`, `api_key`, `reranker_model`, `reranker_top_n`,
+`rerank_required`, `no_rerank`, `dense_only`, `sparse_only`, `fetch_k`, `env`.
+
+## Use
+
+```sh
+export FMQL_EMBEDDING_MODEL=openai/text-embedding-3-small
+export OPENAI_API_KEY=...
+
+# Build once:
+fmql index ./my-notes --backend semantic
+
+# Query:
+fmql search "quarterly planning" --backend semantic --workspace ./my-notes -k 10
+
+# Dense-only / sparse-only / disable rerank for this query:
+fmql search q --backend semantic --workspace ./my-notes --option dense_only=true
+fmql search q --backend semantic --workspace ./my-notes --option sparse_only=true
+fmql search q --backend semantic --workspace ./my-notes --option no_rerank=true
+```
+
+The default index location is `<workspace>/.fmql/semantic.db`. Override with
+`--out` (for `fmql index`) or `--index` (for `fmql search`).
+
+## Indexing
+
+For each packet, the backend indexes:
+
+```
+<first present frontmatter field from --option fields=title,summary,name>
+
+<body>
+```
+
+Frontmatter field *values* are otherwise not indexed — they're already queryable
+via fmql's structured layer.
+
+Builds are incremental: packets whose content hash hasn't changed since the
+last build are skipped. Packets removed from the workspace are removed from the
+index. The index is committed per batch via SQLite WAL, so a crashed build
+leaves a queryable index that the next run picks up.
+
+### Model pinning
+
+An index is pinned to the embedding model that built it. Rebuilding with a
+different model refuses unless you pass `--force` (which drops the existing
+tables). Dimension mismatches are caught the same way.
+
+## Provider notes
+
+- **OpenAI** (`openai/text-embedding-3-small`, `openai/text-embedding-3-large`) —
+  batch caps at 2048; default 100 is fine.
+- **Voyage** (`voyage/voyage-3`) — batch caps at 128. Set `--option
+  batch_size=128` (or lower) for large indexes.
+- **Cohere rerank** (`cohere/rerank-v3.5`) — works as a reranker model out of
+  the box once `COHERE_API_KEY` is set.
+- **Ollama** (`ollama/nomic-embed-text`) — set `OLLAMA_API_BASE` or
+  `--option api_base=http://localhost:11434`.
+
+## Licensing
+
+MIT. See [LICENSE](LICENSE).

--- a/packages/fmql-semantic/pyproject.toml
+++ b/packages/fmql-semantic/pyproject.toml
@@ -5,29 +5,42 @@ build-backend = "hatchling.build"
 [project]
 name = "fmql-semantic"
 version = "0.0.1"
-description = "Semantic search backend plugin for fmql (pre-alpha stub)."
+description = "Semantic (hybrid dense + sparse) search backend plugin for fmql."
 readme = "README.md"
 license = { text = "MIT" }
 license-files = ["LICENSE"]
 requires-python = ">=3.11"
 authors = [{ name = "Michał Michalski", email = "michal@buyuk.io" }]
 classifiers = [
-    "Development Status :: 1 - Planning",
+    "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-dependencies = []
+dependencies = [
+    "fmql>=0.2",
+    "litellm>=1.40",
+    "sqlite-vec>=0.1.6",
+]
+
+[project.optional-dependencies]
+progress = ["tqdm>=4"]
 
 [project.urls]
 Homepage = "https://github.com/buyuk-dev/fmql"
 Repository = "https://github.com/buyuk-dev/fmql"
 Issues = "https://github.com/buyuk-dev/fmql/issues"
 
+[project.entry-points."fmql.search_index"]
+semantic = "fmql_semantic:SemanticBackend"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/fmql_semantic"]
+
+[tool.uv.sources]
+fmql = { workspace = true }
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/packages/fmql-semantic/src/fmql_semantic/__init__.py
+++ b/packages/fmql-semantic/src/fmql_semantic/__init__.py
@@ -1,1 +1,5 @@
 __version__ = "0.0.1"
+
+from fmql_semantic.backend import SemanticBackend
+
+__all__ = ["SemanticBackend", "__version__"]

--- a/packages/fmql-semantic/src/fmql_semantic/backend.py
+++ b/packages/fmql-semantic/src/fmql_semantic/backend.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from fmql import __version__ as fmql_version
+from fmql.packet import Packet
+from fmql.search.errors import BackendUnavailableError, IndexVersionError
+from fmql.search.types import BackendInfo, IndexStats, SearchHit
+from fmql.workspace import Workspace
+from fmql_semantic import __version__ as semantic_version
+from fmql_semantic.config import Config, resolve_config
+from fmql_semantic.dense import dense_search
+from fmql_semantic.embeddings import _embed_batch
+from fmql_semantic.fusion import reciprocal_rank_fusion
+from fmql_semantic.progress import progress
+from fmql_semantic.reranker import rerank
+from fmql_semantic.sparse import sparse_search
+from fmql_semantic.storage import meta as meta_mod
+from fmql_semantic.storage.connection import open_db
+from fmql_semantic.storage.writer import (
+    delete_packets,
+    fetch_existing_hashes,
+    open_for_build,
+    upsert_batch,
+)
+from fmql_semantic.textprep import build_rows
+
+
+class SemanticBackend:
+    """Hybrid (dense + sparse) search backend for fmql."""
+
+    name = "semantic"
+
+    # ------------------------------------------------------------------ IndexedSearch
+
+    def parse_location(self, location: str) -> object:
+        if not location:
+            raise ValueError("semantic backend: location must be a non-empty path")
+        return Path(location)
+
+    def default_location(self, workspace: Workspace) -> str | None:
+        return str(Path(workspace.root) / ".fmql" / "semantic.db")
+
+    def build(
+        self,
+        packets: Iterable[Packet],
+        location: str,
+        *,
+        options: dict | None = None,
+    ) -> IndexStats:
+        cfg = resolve_config(options, kind="build")
+        start = time.monotonic()
+
+        packets_list = list(packets)
+        rows = list(build_rows(packets_list, cfg.fields, cfg.embedding_max_tokens))
+
+        dim = _probe_embedding_dim(cfg)
+
+        conn = open_for_build(
+            location,
+            embedding_model=cfg.embedding_model or "",
+            embedding_dim=dim,
+            fields=cfg.fields,
+            force=cfg.force,
+            fmql_version=fmql_version,
+        )
+        try:
+            existing = fetch_existing_hashes(conn)
+            to_embed: list[tuple[str, str, str]] = []
+            skipped = 0
+            for packet_id, chash, doc in rows:
+                prev = existing.get(packet_id)
+                if prev is not None and prev[1] == chash:
+                    skipped += 1
+                    continue
+                to_embed.append((packet_id, chash, doc))
+
+            current_ids = {pid for pid, _, _ in rows}
+            removed_rowids = [rid for pid, (rid, _) in existing.items() if pid not in current_ids]
+            removed = delete_packets(conn, removed_rowids)
+            conn.commit()
+
+            indexed = 0
+            if to_embed:
+                indexed = asyncio.run(_embed_and_write(conn, to_embed, cfg))
+
+            conn.commit()
+            elapsed = time.monotonic() - start
+            return IndexStats(
+                packets_indexed=indexed,
+                packets_skipped=skipped,
+                packets_removed=removed,
+                elapsed_seconds=elapsed,
+            )
+        finally:
+            conn.close()
+
+    def query(
+        self,
+        text: str,
+        location: str,
+        *,
+        k: int = 10,
+        options: dict | None = None,
+    ) -> list[SearchHit]:
+        cfg = resolve_config(options, kind="query")
+        if not text or k <= 0:
+            return []
+
+        conn = open_db(location, readonly=True, load_vec=not cfg.sparse_only)
+        try:
+            meta = meta_mod.read_all(conn)
+            meta_mod.check_format_version(meta)
+            if not cfg.sparse_only and cfg.embedding_model:
+                meta_mod.check_model_pin(meta, cfg.embedding_model)
+
+            fetch_k = cfg.fetch_k or max(k * 4, 50)
+
+            if cfg.dense_only:
+                qvec = _embed_query(text, cfg)
+                hits = dense_search(conn, qvec, fetch_k=fetch_k)
+                return [SearchHit(packet_id=pid, score=score) for pid, score in hits[:k]]
+
+            if cfg.sparse_only:
+                hits = sparse_search(conn, text, fetch_k=fetch_k)
+                return [SearchHit(packet_id=pid, score=score) for pid, score in hits[:k]]
+
+            qvec = _embed_query(text, cfg)
+            dense = dense_search(conn, qvec, fetch_k=fetch_k)
+            sparse = sparse_search(conn, text, fetch_k=fetch_k)
+            fused = reciprocal_rank_fusion(dense, sparse)
+
+            if cfg.reranker_model and not cfg.rerank_disabled and fused:
+                reranked = _apply_rerank(conn, text, fused, cfg)
+                if reranked is not None:
+                    return [SearchHit(packet_id=pid, score=score) for pid, score in reranked[:k]]
+
+            return [SearchHit(packet_id=pid, score=score) for pid, score in fused[:k]]
+        finally:
+            conn.close()
+
+    def info(self, location: str | None = None) -> BackendInfo:
+        meta_out: dict = {}
+        if location:
+            try:
+                conn = open_db(location, readonly=True, load_vec=False)
+                try:
+                    raw = meta_mod.read_all(conn)
+                finally:
+                    conn.close()
+                try:
+                    meta_mod.check_format_version(raw)
+                    meta_out = {
+                        "format_version": raw.get("format_version"),
+                        "embedding_model": raw.get("embedding_model"),
+                        "embedding_dim": raw.get("embedding_dim"),
+                        "fields": raw.get("fields"),
+                        "built_at": raw.get("built_at"),
+                        "location": location,
+                    }
+                except IndexVersionError as e:
+                    meta_out = {"location": location, "error": str(e)}
+            except FileNotFoundError:
+                meta_out = {"location": location, "error": "index not found"}
+            except Exception as e:
+                meta_out = {"location": location, "error": f"{type(e).__name__}: {e}"}
+        return BackendInfo(
+            name=self.name,
+            version=semantic_version,
+            kind="indexed",
+            metadata=meta_out,
+        )
+
+
+# ---------------------------------------------------------------------------- helpers
+
+
+def _probe_embedding_dim(cfg: Config) -> int:
+    vecs = asyncio.run(
+        _embed_batch(
+            ["fmql semantic dimension probe"],
+            model=cfg.embedding_model or "",
+            api_base=cfg.embedding_api_base,
+            api_key=cfg.embedding_api_key,
+        )
+    )
+    if not vecs or not vecs[0]:
+        raise BackendUnavailableError("embedding probe returned empty result")
+    return len(vecs[0])
+
+
+async def _embed_and_write(conn, to_embed: list[tuple[str, str, str]], cfg: Config) -> int:
+    batch_size = max(1, cfg.embedding_batch_size)
+    concurrency = max(1, cfg.embedding_concurrency)
+    sem = asyncio.Semaphore(concurrency)
+
+    async def _one_batch(rows_chunk: list[tuple[str, str, str]]):
+        async with sem:
+            vecs = await _embed_batch(
+                [doc for _, _, doc in rows_chunk],
+                model=cfg.embedding_model or "",
+                api_base=cfg.embedding_api_base,
+                api_key=cfg.embedding_api_key,
+            )
+            return rows_chunk, vecs
+
+    chunks = [to_embed[i : i + batch_size] for i in range(0, len(to_embed), batch_size)]
+    tasks = [asyncio.create_task(_one_batch(c)) for c in chunks]
+
+    indexed = 0
+    with progress(len(to_embed), desc="embedding") as bar:
+        try:
+            for coro in asyncio.as_completed(tasks):
+                rows_chunk, vecs = await coro
+                upsert_batch(conn, rows_chunk, vecs)
+                conn.commit()
+                indexed += len(rows_chunk)
+                bar.update(len(rows_chunk))  # type: ignore[attr-defined]
+        except BaseException:
+            for t in tasks:
+                if not t.done():
+                    t.cancel()
+            raise
+    return indexed
+
+
+def _embed_query(text: str, cfg: Config) -> list[float]:
+    vecs = asyncio.run(
+        _embed_batch(
+            [text],
+            model=cfg.embedding_model or "",
+            api_base=cfg.embedding_api_base,
+            api_key=cfg.embedding_api_key,
+        )
+    )
+    return vecs[0]
+
+
+def _apply_rerank(
+    conn,
+    query: str,
+    fused: Sequence[tuple[str, float]],
+    cfg: Config,
+) -> list[tuple[str, float]] | None:
+    top = list(fused[: cfg.reranker_top_n])
+    ids = [pid for pid, _ in top]
+    placeholders = ",".join("?" * len(ids))
+    rows = conn.execute(
+        f"SELECT p.packet_id, f.content "
+        f"FROM packets p JOIN packets_fts f ON p.id = f.rowid "
+        f"WHERE p.packet_id IN ({placeholders})",
+        ids,
+    ).fetchall()
+    doc_map = {pid: content for pid, content in rows}
+    documents = [doc_map.get(pid, "") for pid in ids]
+    ordering = rerank(query, documents, cfg=cfg)
+    if ordering is None:
+        return None
+    return [(ids[idx], score) for idx, score in ordering]

--- a/packages/fmql-semantic/src/fmql_semantic/config.py
+++ b/packages/fmql-semantic/src/fmql_semantic/config.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, replace
+from typing import Any, Literal
+
+from fmql_semantic.dotenv import load_dotenv
+from fmql_semantic.errors import ConfigError
+
+DEFAULT_FIELDS: tuple[str, ...] = ("title", "summary", "name")
+
+_BUILD_KEYS = frozenset(
+    {
+        "env",
+        "model",
+        "api_base",
+        "api_key",
+        "batch_size",
+        "concurrency",
+        "max_tokens",
+        "fields",
+        "force",
+    }
+)
+_QUERY_KEYS = frozenset(
+    {
+        "env",
+        "model",
+        "api_base",
+        "api_key",
+        "reranker_model",
+        "reranker_top_n",
+        "rerank_required",
+        "no_rerank",
+        "dense_only",
+        "sparse_only",
+        "fetch_k",
+    }
+)
+
+_ENV_MAP: dict[str, str] = {
+    "FMQL_EMBEDDING_MODEL": "embedding_model",
+    "FMQL_EMBEDDING_API_BASE": "embedding_api_base",
+    "FMQL_EMBEDDING_API_KEY": "embedding_api_key",
+    "FMQL_EMBEDDING_BATCH_SIZE": "embedding_batch_size",
+    "FMQL_EMBEDDING_CONCURRENCY": "embedding_concurrency",
+    "FMQL_EMBEDDING_MAX_TOKENS": "embedding_max_tokens",
+    "FMQL_RERANKER_MODEL": "reranker_model",
+    "FMQL_RERANKER_TOP_N": "reranker_top_n",
+}
+
+_OPT_MAP: dict[str, str] = {
+    "model": "embedding_model",
+    "api_base": "embedding_api_base",
+    "api_key": "embedding_api_key",
+    "batch_size": "embedding_batch_size",
+    "concurrency": "embedding_concurrency",
+    "max_tokens": "embedding_max_tokens",
+    "fields": "fields",
+    "force": "force",
+    "reranker_model": "reranker_model",
+    "reranker_top_n": "reranker_top_n",
+    "rerank_required": "rerank_required",
+    "no_rerank": "rerank_disabled",
+    "dense_only": "dense_only",
+    "sparse_only": "sparse_only",
+    "fetch_k": "fetch_k",
+}
+
+_INT_FIELDS = frozenset(
+    {
+        "embedding_batch_size",
+        "embedding_concurrency",
+        "embedding_max_tokens",
+        "reranker_top_n",
+        "fetch_k",
+    }
+)
+_BOOL_FIELDS = frozenset(
+    {"force", "rerank_required", "rerank_disabled", "dense_only", "sparse_only"}
+)
+
+
+@dataclass(frozen=True)
+class Config:
+    # shared
+    embedding_model: str | None = None
+    embedding_api_base: str | None = None
+    embedding_api_key: str | None = None
+    # build-only
+    embedding_batch_size: int = 100
+    embedding_concurrency: int = 4
+    embedding_max_tokens: int = 8000
+    fields: tuple[str, ...] = DEFAULT_FIELDS
+    force: bool = False
+    # query-only
+    reranker_model: str | None = None
+    reranker_top_n: int = 50
+    rerank_disabled: bool = False
+    rerank_required: bool = False
+    dense_only: bool = False
+    sparse_only: bool = False
+    fetch_k: int | None = None
+
+
+def _coerce(field: str, value: Any) -> Any:
+    if field in _INT_FIELDS:
+        try:
+            return int(value)
+        except (TypeError, ValueError) as e:
+            raise ConfigError(f"{field}: expected integer, got {value!r}") from e
+    if field in _BOOL_FIELDS:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            low = value.strip().lower()
+            if low in {"true", "1", "yes", "on"}:
+                return True
+            if low in {"false", "0", "no", "off"}:
+                return False
+        if isinstance(value, int):
+            return bool(value)
+        raise ConfigError(f"{field}: expected boolean, got {value!r}")
+    if field == "fields":
+        if isinstance(value, str):
+            parts = [p.strip() for p in value.split(",") if p.strip()]
+            return tuple(parts)
+        if isinstance(value, (list, tuple)):
+            return tuple(str(v) for v in value)
+        raise ConfigError(f"fields: expected comma-separated string or list, got {value!r}")
+    return value
+
+
+def resolve_config(options: dict | None, *, kind: Literal["build", "query"]) -> Config:
+    options = dict(options or {})
+    allowed = _BUILD_KEYS if kind == "build" else _QUERY_KEYS
+    unknown = set(options) - allowed
+    if unknown:
+        raise ConfigError(
+            f"unknown options for {kind}: {sorted(unknown)}. Allowed: {sorted(allowed)}."
+        )
+
+    cfg = Config()
+    layered: dict[str, Any] = {}
+
+    for env_key, field in _ENV_MAP.items():
+        if env_key in os.environ:
+            layered[field] = _coerce(field, os.environ[env_key])
+
+    env_path = options.pop("env", None)
+    if env_path is not None:
+        parsed = load_dotenv(env_path)
+        for env_key, field in _ENV_MAP.items():
+            if env_key in parsed:
+                layered[field] = _coerce(field, parsed[env_key])
+
+    for opt_key, value in options.items():
+        field = _OPT_MAP[opt_key]
+        layered[field] = _coerce(field, value)
+
+    cfg = replace(cfg, **layered)
+
+    if kind == "build" and not cfg.embedding_model:
+        raise ConfigError(
+            "missing embedding model: set FMQL_EMBEDDING_MODEL, --option env=path/to/.env, "
+            "or --option model=<litellm-model>. See https://docs.litellm.ai/docs/embedding/supported_embedding"
+        )
+    if kind == "query" and not cfg.sparse_only and not cfg.embedding_model:
+        raise ConfigError(
+            "missing embedding model: set FMQL_EMBEDDING_MODEL, --option env=path/to/.env, "
+            "or --option model=<litellm-model>. Pass --option sparse_only=true to skip embeddings."
+        )
+    if cfg.dense_only and cfg.sparse_only:
+        raise ConfigError("dense_only and sparse_only are mutually exclusive")
+
+    return cfg

--- a/packages/fmql-semantic/src/fmql_semantic/dense.py
+++ b/packages/fmql-semantic/src/fmql_semantic/dense.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import sqlite3
+from typing import Sequence
+
+from sqlite_vec import serialize_float32  # type: ignore
+
+
+def dense_search(
+    conn: sqlite3.Connection,
+    query_vec: Sequence[float],
+    *,
+    fetch_k: int,
+) -> list[tuple[str, float]]:
+    """Return [(packet_id, score)] ordered by descending similarity. Score = -distance."""
+    rows = conn.execute(
+        "SELECT v.rowid, v.distance, p.packet_id "
+        "FROM vectors v JOIN packets p ON p.id = v.rowid "
+        "WHERE v.embedding MATCH ? AND k = ? "
+        "ORDER BY v.distance",
+        (serialize_float32(list(query_vec)), fetch_k),
+    ).fetchall()
+    return [(packet_id, -float(distance)) for _, distance, packet_id in rows]

--- a/packages/fmql-semantic/src/fmql_semantic/dotenv.py
+++ b/packages/fmql-semantic/src/fmql_semantic/dotenv.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fmql_semantic.errors import ConfigError
+
+
+def load_dotenv(path: str | Path) -> dict[str, str]:
+    p = Path(path)
+    if not p.exists():
+        raise ConfigError(f"dotenv file not found: {p}")
+    out: dict[str, str] = {}
+    for lineno, raw in enumerate(p.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].lstrip()
+        if "=" not in line:
+            raise ConfigError(f"{p}:{lineno}: expected KEY=VALUE, got {raw!r}")
+        key, _, value = line.partition("=")
+        key = key.strip()
+        if not key:
+            raise ConfigError(f"{p}:{lineno}: empty key")
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+            value = value[1:-1]
+        out[key] = value
+    return out

--- a/packages/fmql-semantic/src/fmql_semantic/embeddings.py
+++ b/packages/fmql-semantic/src/fmql_semantic/embeddings.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Sequence
+
+from fmql.search.errors import BackendUnavailableError
+from fmql_semantic.config import Config
+
+
+async def _embed_batch(
+    texts: Sequence[str],
+    *,
+    model: str,
+    api_base: str | None,
+    api_key: str | None,
+) -> list[list[float]]:
+    import litellm  # type: ignore
+
+    kwargs: dict = {"model": model, "input": list(texts)}
+    if api_base:
+        kwargs["api_base"] = api_base
+    if api_key:
+        kwargs["api_key"] = api_key
+    try:
+        resp = await litellm.aembedding(**kwargs)
+    except Exception as e:
+        raise BackendUnavailableError(f"embedding call failed ({type(e).__name__}): {e}") from e
+    data = getattr(resp, "data", None) or resp["data"]
+    return [list(item["embedding"]) for item in data]
+
+
+def embed_sync(text: str, cfg: Config) -> list[float]:
+    """Synchronously embed a single string via the configured model (used for query-time probe)."""
+    if not cfg.embedding_model:
+        raise BackendUnavailableError("embed_sync called without a configured model")
+    vecs = asyncio.run(
+        _embed_batch(
+            [text],
+            model=cfg.embedding_model,
+            api_base=cfg.embedding_api_base,
+            api_key=cfg.embedding_api_key,
+        )
+    )
+    return vecs[0]
+
+
+async def embed_many(
+    texts: Sequence[str],
+    *,
+    cfg: Config,
+) -> list[list[float]]:
+    """Batch + bounded-concurrency embedding. Partial failures cancel pending work."""
+    if not cfg.embedding_model:
+        raise BackendUnavailableError("embed_many called without a configured model")
+    if not texts:
+        return []
+
+    batch_size = max(1, cfg.embedding_batch_size)
+    concurrency = max(1, cfg.embedding_concurrency)
+
+    chunks: list[list[str]] = [
+        list(texts[i : i + batch_size]) for i in range(0, len(texts), batch_size)
+    ]
+    sem = asyncio.Semaphore(concurrency)
+
+    async def _run(chunk: list[str]) -> list[list[float]]:
+        async with sem:
+            return await _embed_batch(
+                chunk,
+                model=cfg.embedding_model,
+                api_base=cfg.embedding_api_base,
+                api_key=cfg.embedding_api_key,
+            )
+
+    results = await asyncio.gather(*[_run(c) for c in chunks])
+    flat: list[list[float]] = []
+    for r in results:
+        flat.extend(r)
+    return flat

--- a/packages/fmql-semantic/src/fmql_semantic/errors.py
+++ b/packages/fmql-semantic/src/fmql_semantic/errors.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from fmql.errors import FmqlError
+
+
+class ConfigError(FmqlError):
+    """Invalid or missing backend configuration (bad option key, missing model, missing dotenv)."""

--- a/packages/fmql-semantic/src/fmql_semantic/fusion.py
+++ b/packages/fmql-semantic/src/fmql_semantic/fusion.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+K_RRF = 60
+
+
+def reciprocal_rank_fusion(
+    *ranked_lists: Sequence[tuple[str, float]],
+    k_rrf: int = K_RRF,
+) -> list[tuple[str, float]]:
+    """Combine ranked `[(id, score)]` lists via reciprocal rank fusion.
+
+    Score contribution from list L: 1 / (k_rrf + rank_L(id)), where rank_L is 1-based.
+    IDs absent from a list contribute 0 from it.
+    Returns [(id, rrf_score)] sorted by rrf_score descending.
+    """
+    totals: dict[str, float] = {}
+    for lst in ranked_lists:
+        for rank, (pid, _score) in enumerate(lst, start=1):
+            totals[pid] = totals.get(pid, 0.0) + 1.0 / (k_rrf + rank)
+    return sorted(totals.items(), key=lambda kv: kv[1], reverse=True)

--- a/packages/fmql-semantic/src/fmql_semantic/progress.py
+++ b/packages/fmql-semantic/src/fmql_semantic/progress.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import sys
+from contextlib import contextmanager
+from typing import Iterator, Optional
+
+
+class _NoopBar:
+    def update(self, n: int = 1) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+@contextmanager
+def progress(total: int, *, desc: str = "") -> Iterator[object]:
+    """tqdm-backed progress bar on stderr TTYs, no-op otherwise. tqdm is an optional dep."""
+    bar: Optional[object] = None
+    if total > 0 and sys.stderr.isatty():
+        try:
+            from tqdm import tqdm  # type: ignore
+
+            bar = tqdm(total=total, desc=desc, unit="pkt", file=sys.stderr, leave=False)
+        except ImportError:
+            bar = None
+    if bar is None:
+        bar = _NoopBar()
+    try:
+        yield bar
+    finally:
+        bar.close()

--- a/packages/fmql-semantic/src/fmql_semantic/reranker.py
+++ b/packages/fmql-semantic/src/fmql_semantic/reranker.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Sequence
+
+from fmql.search.errors import BackendUnavailableError
+from fmql_semantic.config import Config
+
+logger = logging.getLogger("fmql_semantic.reranker")
+
+
+def rerank(
+    query: str,
+    documents: Sequence[str],
+    *,
+    cfg: Config,
+) -> list[tuple[int, float]] | None:
+    """Rerank `documents` against `query`. Returns [(index, score)] sorted by score desc,
+    or None if reranking was skipped (soft-fail)."""
+    if not cfg.reranker_model or cfg.rerank_disabled or not documents:
+        return None
+    try:
+        return asyncio.run(_rerank_async(query, documents, cfg=cfg))
+    except BackendUnavailableError:
+        if cfg.rerank_required:
+            raise
+        logger.warning(
+            "rerank call failed; falling back to RRF ordering. "
+            "Pass --option rerank_required=true to make this a hard error."
+        )
+        return None
+
+
+async def _rerank_async(
+    query: str,
+    documents: Sequence[str],
+    *,
+    cfg: Config,
+) -> list[tuple[int, float]]:
+    import litellm  # type: ignore
+
+    kwargs: dict = {
+        "model": cfg.reranker_model,
+        "query": query,
+        "documents": list(documents),
+        "top_n": min(cfg.reranker_top_n, len(documents)),
+    }
+    if cfg.embedding_api_base:
+        kwargs["api_base"] = cfg.embedding_api_base
+    if cfg.embedding_api_key:
+        kwargs["api_key"] = cfg.embedding_api_key
+    try:
+        resp = await litellm.arerank(**kwargs)
+    except Exception as e:
+        raise BackendUnavailableError(f"rerank call failed ({type(e).__name__}): {e}") from e
+
+    results = _extract_results(resp)
+    return sorted(
+        [(int(r["index"]), float(r.get("relevance_score", r.get("score", 0.0)))) for r in results],
+        key=lambda p: p[1],
+        reverse=True,
+    )
+
+
+def _extract_results(resp: object) -> list[dict]:
+    if isinstance(resp, dict) and "results" in resp:
+        return list(resp["results"])
+    results = getattr(resp, "results", None)
+    if results is not None:
+        return [dict(r) if not isinstance(r, dict) else r for r in results]
+    raise BackendUnavailableError(f"unexpected rerank response shape: {type(resp).__name__}")

--- a/packages/fmql-semantic/src/fmql_semantic/sparse.py
+++ b/packages/fmql-semantic/src/fmql_semantic/sparse.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import re
+import sqlite3
+
+_WORD_RE = re.compile(r"\w+", re.UNICODE)
+
+
+def _fts5_query(text: str) -> str:
+    words = _WORD_RE.findall(text)
+    if not words:
+        return ""
+    return " OR ".join(f'"{w}"' for w in words)
+
+
+def sparse_search(
+    conn: sqlite3.Connection,
+    query: str,
+    *,
+    fetch_k: int,
+) -> list[tuple[str, float]]:
+    """Return [(packet_id, score)] ordered by descending BM25 relevance. Score = -bm25."""
+    q = _fts5_query(query)
+    if not q:
+        return []
+    rows = conn.execute(
+        "SELECT f.rowid, bm25(packets_fts) AS s, p.packet_id "
+        "FROM packets_fts f JOIN packets p ON p.id = f.rowid "
+        "WHERE packets_fts MATCH ? "
+        "ORDER BY s "
+        "LIMIT ?",
+        (q, fetch_k),
+    ).fetchall()
+    return [(packet_id, -float(s)) for _, s, packet_id in rows]

--- a/packages/fmql-semantic/src/fmql_semantic/storage/connection.py
+++ b/packages/fmql-semantic/src/fmql_semantic/storage/connection.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from fmql.search.errors import BackendUnavailableError
+
+
+def open_db(
+    path: str | Path, *, readonly: bool = False, load_vec: bool = True
+) -> sqlite3.Connection:
+    p = Path(path)
+    if readonly:
+        if not p.exists():
+            raise FileNotFoundError(f"index not found: {p}")
+        uri = f"file:{p.as_posix()}?mode=ro"
+        conn = sqlite3.connect(uri, uri=True)
+    else:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(p))
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=NORMAL")
+
+    if load_vec:
+        try:
+            conn.enable_load_extension(True)
+        except (AttributeError, sqlite3.NotSupportedError) as e:
+            conn.close()
+            raise BackendUnavailableError(
+                "this Python build's sqlite3 module does not support loadable extensions, "
+                "which sqlite-vec requires. Install Python via uv/pyenv/python.org "
+                "(not the macOS system Python or a distro build compiled without "
+                "--enable-loadable-sqlite-extensions)."
+            ) from e
+        try:
+            import sqlite_vec  # type: ignore
+
+            sqlite_vec.load(conn)
+        except ImportError as e:
+            conn.close()
+            raise BackendUnavailableError(
+                "sqlite-vec is not installed. Install it with `pip install sqlite-vec`."
+            ) from e
+        finally:
+            try:
+                conn.enable_load_extension(False)
+            except Exception:
+                pass
+    return conn
+
+
+def probe_extension_support() -> bool:
+    """True iff this Python can load sqlite extensions AND sqlite-vec is importable."""
+    try:
+        conn = sqlite3.connect(":memory:")
+    except sqlite3.Error:
+        return False
+    try:
+        try:
+            conn.enable_load_extension(True)
+        except (AttributeError, sqlite3.NotSupportedError):
+            return False
+        try:
+            import sqlite_vec  # type: ignore
+
+            sqlite_vec.load(conn)
+        except ImportError:
+            return False
+        except sqlite3.Error:
+            return False
+        return True
+    finally:
+        conn.close()

--- a/packages/fmql-semantic/src/fmql_semantic/storage/meta.py
+++ b/packages/fmql-semantic/src/fmql_semantic/storage/meta.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import sqlite3
+
+from fmql.search.errors import BackendUnavailableError, IndexVersionError
+from fmql_semantic.storage.schema import FORMAT_VERSION
+
+
+def read_all(conn: sqlite3.Connection) -> dict[str, str]:
+    try:
+        rows = conn.execute("SELECT key, value FROM meta").fetchall()
+    except sqlite3.OperationalError:
+        return {}
+    return {k: v for k, v in rows}
+
+
+def write(conn: sqlite3.Connection, values: dict[str, str]) -> None:
+    conn.executemany(
+        "INSERT INTO meta(key, value) VALUES(?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+        [(k, str(v)) for k, v in values.items()],
+    )
+
+
+def check_format_version(meta: dict[str, str]) -> None:
+    raw = meta.get("format_version")
+    if raw is None:
+        return
+    try:
+        stored = int(raw)
+    except ValueError as e:
+        raise IndexVersionError(
+            f"index has malformed format_version={raw!r}; rebuild with --force"
+        ) from e
+    if stored != FORMAT_VERSION:
+        raise IndexVersionError(
+            f"index format_version={stored} is incompatible with this backend "
+            f"(expected {FORMAT_VERSION}). Rebuild with "
+            f"`fmql index ... --backend semantic --force`."
+        )
+
+
+def check_model_pin(meta: dict[str, str], requested_model: str) -> None:
+    stored = meta.get("embedding_model")
+    if stored and stored != requested_model:
+        raise BackendUnavailableError(
+            f"index was built with embedding model {stored!r}, but the current request "
+            f"uses {requested_model!r}. Pass --force to rebuild from scratch, or use the "
+            f"original model."
+        )

--- a/packages/fmql-semantic/src/fmql_semantic/storage/schema.py
+++ b/packages/fmql-semantic/src/fmql_semantic/storage/schema.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+FORMAT_VERSION = 1
+
+CREATE_META = """
+CREATE TABLE IF NOT EXISTS meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+)
+"""
+
+CREATE_PACKETS = """
+CREATE TABLE IF NOT EXISTS packets (
+    id INTEGER PRIMARY KEY,
+    packet_id TEXT NOT NULL UNIQUE,
+    content_hash TEXT NOT NULL,
+    indexed_at TEXT NOT NULL
+)
+"""
+
+CREATE_PACKETS_FTS = """
+CREATE VIRTUAL TABLE IF NOT EXISTS packets_fts USING fts5(
+    content,
+    tokenize = 'unicode61 remove_diacritics 2'
+)
+"""
+
+
+def create_vectors_sql(dim: int) -> str:
+    if dim <= 0:
+        raise ValueError(f"embedding dimension must be positive, got {dim}")
+    return f"CREATE VIRTUAL TABLE IF NOT EXISTS vectors USING vec0(embedding float[{dim}])"
+
+
+DROP_ALL = [
+    "DROP TABLE IF EXISTS vectors",
+    "DROP TABLE IF EXISTS packets_fts",
+    "DROP TABLE IF EXISTS packets",
+    "DROP TABLE IF EXISTS meta",
+]

--- a/packages/fmql-semantic/src/fmql_semantic/storage/writer.py
+++ b/packages/fmql-semantic/src/fmql_semantic/storage/writer.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from sqlite_vec import serialize_float32  # type: ignore
+
+from fmql_semantic import __version__ as semantic_version
+from fmql_semantic.storage import meta as meta_mod
+from fmql_semantic.storage.connection import open_db
+from fmql_semantic.storage.schema import (
+    CREATE_META,
+    CREATE_PACKETS,
+    CREATE_PACKETS_FTS,
+    DROP_ALL,
+    FORMAT_VERSION,
+    create_vectors_sql,
+)
+
+
+def _drop_all(conn: sqlite3.Connection) -> None:
+    for stmt in DROP_ALL:
+        conn.execute(stmt)
+
+
+def _ensure_tables(conn: sqlite3.Connection, *, dim: int) -> None:
+    conn.execute(CREATE_META)
+    conn.execute(CREATE_PACKETS)
+    conn.execute(create_vectors_sql(dim))
+    conn.execute(CREATE_PACKETS_FTS)
+
+
+def open_for_build(
+    location: str,
+    *,
+    embedding_model: str,
+    embedding_dim: int,
+    fields: Sequence[str],
+    force: bool,
+    fmql_version: str,
+) -> sqlite3.Connection:
+    """Open or create the index for writing.
+
+    Validates format_version and model pin; on mismatch + force=True, drops everything.
+    Creates tables if missing. Writes meta.
+    """
+    path = Path(location)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    exists = path.exists()
+
+    conn = open_db(location, readonly=False, load_vec=True)
+    try:
+        if exists and force:
+            _drop_all(conn)
+            conn.commit()
+            exists = False
+
+        meta = meta_mod.read_all(conn) if exists else {}
+        if meta:
+            meta_mod.check_format_version(meta)
+            meta_mod.check_model_pin(meta, embedding_model)
+            stored_dim = meta.get("embedding_dim")
+            if stored_dim and int(stored_dim) != embedding_dim:
+                raise RuntimeError(
+                    f"existing index dim={stored_dim} differs from current probe {embedding_dim}; "
+                    "this should have been caught by check_model_pin"
+                )
+
+        _ensure_tables(conn, dim=embedding_dim)
+        meta_mod.write(
+            conn,
+            {
+                "format_version": str(FORMAT_VERSION),
+                "backend_version": semantic_version,
+                "fmql_version": fmql_version,
+                "embedding_model": embedding_model,
+                "embedding_dim": str(embedding_dim),
+                "fields": ",".join(fields),
+                "built_at": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+        conn.commit()
+    except Exception:
+        conn.close()
+        raise
+    return conn
+
+
+def fetch_existing_hashes(conn: sqlite3.Connection) -> dict[str, tuple[int, str]]:
+    """Return {packet_id: (rowid, content_hash)} for all currently indexed packets."""
+    rows = conn.execute("SELECT id, packet_id, content_hash FROM packets").fetchall()
+    return {pid: (rid, h) for rid, pid, h in rows}
+
+
+def delete_packets(conn: sqlite3.Connection, rowids: Iterable[int]) -> int:
+    rowids_list = list(rowids)
+    if not rowids_list:
+        return 0
+    placeholders = ",".join("?" * len(rowids_list))
+    conn.execute(f"DELETE FROM vectors WHERE rowid IN ({placeholders})", rowids_list)
+    conn.execute(f"DELETE FROM packets_fts WHERE rowid IN ({placeholders})", rowids_list)
+    conn.execute(f"DELETE FROM packets WHERE id IN ({placeholders})", rowids_list)
+    return len(rowids_list)
+
+
+def _next_rowid(conn: sqlite3.Connection) -> int:
+    row = conn.execute("SELECT COALESCE(MAX(id), 0) FROM packets").fetchone()
+    return int(row[0]) + 1
+
+
+def upsert_batch(
+    conn: sqlite3.Connection,
+    rows: Sequence[tuple[str, str, str]],
+    embeddings: Sequence[Sequence[float]],
+) -> None:
+    """rows: [(packet_id, content_hash, document_text), ...] aligned with `embeddings`."""
+    if not rows:
+        return
+    assert len(rows) == len(embeddings), "rows/embeddings length mismatch"
+    now = datetime.now(timezone.utc).isoformat()
+
+    existing = conn.execute(
+        f"SELECT packet_id, id FROM packets WHERE packet_id IN ({','.join('?' * len(rows))})",
+        [pid for pid, _, _ in rows],
+    ).fetchall()
+    existing_map = {pid: rid for pid, rid in existing}
+
+    for (packet_id, chash, doc), vec in zip(rows, embeddings):
+        if packet_id in existing_map:
+            rowid = existing_map[packet_id]
+            conn.execute(
+                "UPDATE packets SET content_hash=?, indexed_at=? WHERE id=?",
+                (chash, now, rowid),
+            )
+            conn.execute("DELETE FROM vectors WHERE rowid=?", (rowid,))
+            conn.execute("DELETE FROM packets_fts WHERE rowid=?", (rowid,))
+        else:
+            rowid = _next_rowid(conn)
+            conn.execute(
+                "INSERT INTO packets(id, packet_id, content_hash, indexed_at) VALUES(?,?,?,?)",
+                (rowid, packet_id, chash, now),
+            )
+        conn.execute(
+            "INSERT INTO vectors(rowid, embedding) VALUES(?, ?)",
+            (rowid, serialize_float32(list(vec))),
+        )
+        conn.execute(
+            "INSERT INTO packets_fts(rowid, content) VALUES(?, ?)",
+            (rowid, doc),
+        )

--- a/packages/fmql-semantic/src/fmql_semantic/textprep.py
+++ b/packages/fmql-semantic/src/fmql_semantic/textprep.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import hashlib
+import warnings
+from typing import Iterable, Iterator
+
+from fmql.packet import Packet
+
+
+def pick_frontmatter_field(packet: Packet, fields: Iterable[str]) -> tuple[str | None, str | None]:
+    """Return (field_name, stringified_value) of the first present, non-empty field."""
+    data = packet.as_plain()
+    for f in fields:
+        if f in data:
+            value = data[f]
+            if value is None:
+                continue
+            text = str(value).strip()
+            if text:
+                return f, text
+    return None, None
+
+
+def _truncate_chars(text: str, max_tokens: int) -> tuple[str, bool]:
+    """Cheap proxy for token truncation: assume ~4 chars/token."""
+    limit = max_tokens * 4
+    if len(text) <= limit:
+        return text, False
+    return text[:limit], True
+
+
+def build_document(packet: Packet, fields: Iterable[str], max_tokens: int) -> tuple[str, bool]:
+    field_name, field_value = pick_frontmatter_field(packet, fields)
+    parts: list[str] = []
+    if field_value:
+        parts.append(field_value)
+    if packet.body:
+        parts.append(packet.body.strip())
+    doc = "\n\n".join(p for p in parts if p)
+    return _truncate_chars(doc, max_tokens)
+
+
+def content_hash(packet: Packet, fields: Iterable[str], max_tokens: int) -> str:
+    doc, _ = build_document(packet, fields, max_tokens)
+    fields_tuple = tuple(fields)
+    h = hashlib.sha256()
+    h.update("|".join(fields_tuple).encode("utf-8"))
+    h.update(b"\n")
+    h.update(doc.encode("utf-8"))
+    return h.hexdigest()
+
+
+def build_rows(
+    packets: Iterable[Packet],
+    fields: Iterable[str],
+    max_tokens: int,
+) -> Iterator[tuple[str, str, str]]:
+    """Yield (packet_id, content_hash, document_text). Warns once if any row was truncated."""
+    fields_tuple = tuple(fields)
+    warned = False
+    for packet in packets:
+        doc, truncated = build_document(packet, fields_tuple, max_tokens)
+        if truncated and not warned:
+            warnings.warn(
+                f"fmql-semantic: truncated packet {packet.id!r} to {max_tokens} tokens "
+                f"(~{max_tokens * 4} chars). Raise --option max_tokens=N to change.",
+                stacklevel=2,
+            )
+            warned = True
+        h = hashlib.sha256()
+        h.update("|".join(fields_tuple).encode("utf-8"))
+        h.update(b"\n")
+        h.update(doc.encode("utf-8"))
+        yield packet.id, h.hexdigest(), doc

--- a/packages/fmql-semantic/tests/conftest.py
+++ b/packages/fmql-semantic/tests/conftest.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from fmql_semantic.storage.connection import probe_extension_support  # noqa: E402
+
+if not probe_extension_support():
+    import pytest as _pytest  # noqa
+
+    _pytest.skip(
+        "Python build lacks sqlite3 loadable extensions or sqlite-vec is not importable. "
+        "Install via uv/pyenv/python.org.",
+        allow_module_level=True,
+    )
+
+from fakes.provider import fake_aembedding, fake_arerank  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def patch_litellm(monkeypatch):
+    import litellm  # type: ignore
+
+    monkeypatch.setattr(litellm, "aembedding", fake_aembedding, raising=False)
+    monkeypatch.setattr(litellm, "arerank", fake_arerank, raising=False)
+    yield
+
+
+@pytest.fixture
+def tmp_location(tmp_path: Path) -> str:
+    return str(tmp_path / "index.db")
+
+
+@pytest.fixture
+def ws_root(tmp_path: Path) -> Path:
+    d = tmp_path / "ws"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def embed_model_env(monkeypatch):
+    monkeypatch.setenv("FMQL_EMBEDDING_MODEL", "fake/embed")

--- a/packages/fmql-semantic/tests/fakes/hashing.py
+++ b/packages/fmql-semantic/tests/fakes/hashing.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import hashlib
+import math
+
+
+def deterministic_vector(text: str, dim: int = 8) -> list[float]:
+    """SHA256-derived, L2-normalised vector. Stable across runs and platforms."""
+    digest = hashlib.sha256(text.encode("utf-8")).digest()
+    vals: list[float] = []
+    i = 0
+    while len(vals) < dim:
+        if i >= len(digest):
+            digest = hashlib.sha256(digest).digest()
+            i = 0
+        byte = digest[i]
+        vals.append(byte / 255.0 - 0.5)
+        i += 1
+    norm = math.sqrt(sum(v * v for v in vals))
+    if norm == 0:
+        return vals
+    return [v / norm for v in vals]
+
+
+def cosine(a: list[float], b: list[float]) -> float:
+    return sum(x * y for x, y in zip(a, b))

--- a/packages/fmql-semantic/tests/fakes/provider.py
+++ b/packages/fmql-semantic/tests/fakes/provider.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fakes.hashing import cosine, deterministic_vector
+
+DIM = 8
+
+
+class FailingEmbedder:
+    def __init__(self, exception: Exception) -> None:
+        self.exception = exception
+        self.calls = 0
+
+    async def __call__(self, *, model: str, input: list[str], **kwargs: Any) -> dict:
+        self.calls += 1
+        raise self.exception
+
+
+class FailingReranker:
+    def __init__(self, exception: Exception) -> None:
+        self.exception = exception
+        self.calls = 0
+
+    async def __call__(
+        self, *, model: str, query: str, documents: list[str], **kwargs: Any
+    ) -> dict:
+        self.calls += 1
+        raise self.exception
+
+
+async def fake_aembedding(*, model: str, input: list[str], **kwargs: Any) -> dict:
+    vecs = [deterministic_vector(t, DIM) for t in input]
+    return {
+        "object": "list",
+        "model": model,
+        "data": [{"object": "embedding", "index": i, "embedding": v} for i, v in enumerate(vecs)],
+        "usage": {"prompt_tokens": 0, "total_tokens": 0},
+    }
+
+
+async def fake_arerank(
+    *,
+    model: str,
+    query: str,
+    documents: list[str],
+    top_n: int | None = None,
+    **kwargs: Any,
+) -> dict:
+    qvec = deterministic_vector(query, DIM)
+    scored = [(i, cosine(qvec, deterministic_vector(doc, DIM))) for i, doc in enumerate(documents)]
+    scored.sort(key=lambda p: p[1], reverse=True)
+    if top_n is not None:
+        scored = scored[:top_n]
+    return {"results": [{"index": i, "relevance_score": s} for i, s in scored]}

--- a/packages/fmql-semantic/tests/test_build.py
+++ b/packages/fmql-semantic/tests/test_build.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fmql.search.errors import BackendUnavailableError
+from fmql.workspace import Workspace
+from fmql_semantic import SemanticBackend
+
+
+@pytest.fixture(autouse=True)
+def _env_model(monkeypatch):
+    monkeypatch.setenv("FMQL_EMBEDDING_MODEL", "fake/embed")
+
+
+def _ws(root: Path, files: dict[str, str]) -> Workspace:
+    root.mkdir(parents=True, exist_ok=True)
+    for path in list(root.iterdir()):
+        if path.is_file():
+            path.unlink()
+    for rel, content in files.items():
+        (root / rel).write_text(content, encoding="utf-8")
+    return Workspace(root)
+
+
+def test_incremental_skip_when_nothing_changes(tmp_path: Path):
+    ws = _ws(
+        tmp_path / "ws",
+        {
+            "a.md": "---\ntitle: A\n---\nalpha text\n",
+            "b.md": "---\ntitle: B\n---\nbeta text\n",
+        },
+    )
+    backend = SemanticBackend()
+    loc = str(tmp_path / "idx.db")
+    stats1 = backend.build(list(ws.packets.values()), loc)
+    assert stats1.packets_indexed == 2
+    assert stats1.packets_skipped == 0
+    stats2 = backend.build(list(ws.packets.values()), loc)
+    assert stats2.packets_indexed == 0
+    assert stats2.packets_skipped == 2
+
+
+def test_incremental_only_edited_packet_reembeds(tmp_path: Path):
+    root = tmp_path / "ws"
+    ws1 = _ws(
+        root,
+        {
+            "a.md": "---\ntitle: A\n---\nalpha\n",
+            "b.md": "---\ntitle: B\n---\nbeta\n",
+        },
+    )
+    backend = SemanticBackend()
+    loc = str(tmp_path / "idx.db")
+    backend.build(list(ws1.packets.values()), loc)
+    ws2 = _ws(
+        root,
+        {
+            "a.md": "---\ntitle: A\n---\nalpha edited\n",
+            "b.md": "---\ntitle: B\n---\nbeta\n",
+        },
+    )
+    stats = backend.build(list(ws2.packets.values()), loc)
+    assert stats.packets_indexed == 1
+    assert stats.packets_skipped == 1
+
+
+def test_deletion_reflected_on_rebuild(tmp_path: Path):
+    root = tmp_path / "ws"
+    ws1 = _ws(
+        root,
+        {
+            "a.md": "---\n---\nalpha\n",
+            "b.md": "---\n---\nbeta\n",
+        },
+    )
+    backend = SemanticBackend()
+    loc = str(tmp_path / "idx.db")
+    backend.build(list(ws1.packets.values()), loc)
+    ws2 = _ws(root, {"a.md": "---\n---\nalpha\n"})
+    stats = backend.build(list(ws2.packets.values()), loc)
+    assert stats.packets_removed == 1
+    hits = backend.query("beta", loc)
+    assert not any(h.packet_id == "b.md" for h in hits)
+
+
+def test_partial_failure_leaves_prior_batch_committed(tmp_path: Path, monkeypatch):
+    import litellm  # type: ignore
+    from fakes.provider import fake_aembedding
+
+    ws = _ws(
+        tmp_path / "ws",
+        {f"f{i}.md": f"---\n---\nbody {i}\n" for i in range(6)},
+    )
+    backend = SemanticBackend()
+    loc = str(tmp_path / "idx.db")
+
+    call = {"n": 0}
+
+    async def _maybe_fail(**kwargs):
+        call["n"] += 1
+        if call["n"] == 4:
+            raise RuntimeError("simulated provider error")
+        return await fake_aembedding(**kwargs)
+
+    monkeypatch.setattr(litellm, "aembedding", _maybe_fail)
+
+    with pytest.raises(BackendUnavailableError):
+        backend.build(list(ws.packets.values()), loc, options={"batch_size": 1, "concurrency": 1})
+
+    # Restore full provider; previously committed batches should have persisted.
+    monkeypatch.setattr(litellm, "aembedding", fake_aembedding)
+    stats = backend.build(list(ws.packets.values()), loc)
+    total_after_resume = stats.packets_indexed + stats.packets_skipped
+    assert total_after_resume == 6
+    assert stats.packets_skipped >= 1, "at least one row should have survived the crash"
+
+
+def test_force_rebuild_ignores_existing(tmp_path: Path):
+    ws = _ws(tmp_path / "ws", {"a.md": "---\n---\nalpha\n"})
+    backend = SemanticBackend()
+    loc = str(tmp_path / "idx.db")
+    backend.build(list(ws.packets.values()), loc)
+    stats = backend.build(list(ws.packets.values()), loc, options={"force": True})
+    assert stats.packets_indexed == 1
+    assert stats.packets_skipped == 0

--- a/packages/fmql-semantic/tests/test_config.py
+++ b/packages/fmql-semantic/tests/test_config.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fmql_semantic.config import DEFAULT_FIELDS, Config, resolve_config
+from fmql_semantic.errors import ConfigError
+
+
+def test_defaults_for_build_require_model():
+    with pytest.raises(ConfigError, match="embedding model"):
+        resolve_config({}, kind="build")
+
+
+def test_env_provides_model(monkeypatch):
+    monkeypatch.setenv("FMQL_EMBEDDING_MODEL", "env/model")
+    cfg = resolve_config({}, kind="build")
+    assert cfg.embedding_model == "env/model"
+    assert cfg.fields == DEFAULT_FIELDS
+    assert isinstance(cfg, Config)
+
+
+def test_option_overrides_env(monkeypatch):
+    monkeypatch.setenv("FMQL_EMBEDDING_MODEL", "env/model")
+    cfg = resolve_config({"model": "opt/model"}, kind="build")
+    assert cfg.embedding_model == "opt/model"
+
+
+def test_dotenv_layered_between_env_and_options(monkeypatch, tmp_path: Path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("FMQL_EMBEDDING_MODEL=dotenv/model\nFMQL_EMBEDDING_API_KEY=dotenv-key\n")
+    monkeypatch.setenv("FMQL_EMBEDDING_MODEL", "proc/model")
+    cfg = resolve_config({"env": str(env_file), "model": "opt/model"}, kind="build")
+    assert cfg.embedding_model == "opt/model"
+    assert cfg.embedding_api_key == "dotenv-key"
+
+
+def test_missing_dotenv_errors():
+    with pytest.raises(ConfigError, match="dotenv file not found"):
+        resolve_config({"env": "/nonexistent/file.env"}, kind="build")
+
+
+def test_unknown_option_for_build():
+    with pytest.raises(ConfigError, match="unknown options for build"):
+        resolve_config({"model": "m", "reranker_model": "r"}, kind="build")
+
+
+def test_unknown_option_for_query():
+    with pytest.raises(ConfigError, match="unknown options for query"):
+        resolve_config({"model": "m", "batch_size": 10}, kind="query")
+
+
+def test_fields_coerced_from_csv():
+    cfg = resolve_config({"model": "m", "fields": "title,slug,name"}, kind="build")
+    assert cfg.fields == ("title", "slug", "name")
+
+
+def test_fields_from_list():
+    cfg = resolve_config({"model": "m", "fields": ["a", "b"]}, kind="build")
+    assert cfg.fields == ("a", "b")
+
+
+def test_int_coercion():
+    cfg = resolve_config({"model": "m", "batch_size": "50"}, kind="build")
+    assert cfg.embedding_batch_size == 50
+
+
+def test_bool_coercion():
+    cfg = resolve_config({"model": "m", "force": "true"}, kind="build")
+    assert cfg.force is True
+    cfg = resolve_config({"model": "m", "force": False}, kind="build")
+    assert cfg.force is False
+
+
+def test_query_dense_only_requires_model():
+    with pytest.raises(ConfigError, match="embedding model"):
+        resolve_config({"dense_only": True}, kind="query")
+
+
+def test_query_sparse_only_needs_no_model():
+    cfg = resolve_config({"sparse_only": True}, kind="query")
+    assert cfg.sparse_only is True
+    assert cfg.embedding_model is None
+
+
+def test_dense_and_sparse_mutually_exclusive():
+    with pytest.raises(ConfigError, match="mutually exclusive"):
+        resolve_config({"model": "m", "dense_only": True, "sparse_only": True}, kind="query")

--- a/packages/fmql-semantic/tests/test_conformance.py
+++ b/packages/fmql-semantic/tests/test_conformance.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from fmql.search.conformance import (
+    assert_indexed_build_is_idempotent,
+    assert_indexed_build_then_query,
+    assert_indexed_handles_deletion,
+    assert_indexed_info_tolerates_missing,
+    assert_indexed_version_mismatch_raises,
+    default_workspace_factory,
+)
+from fmql_semantic import SemanticBackend
+
+
+@pytest.fixture(autouse=True)
+def _env_model(monkeypatch):
+    monkeypatch.setenv("FMQL_EMBEDDING_MODEL", "fake/embed")
+
+
+def _fresh_ws(tmp_path: Path) -> Path:
+    d = tmp_path / "ws"
+    d.mkdir()
+    return d
+
+
+def test_build_then_query(tmp_path: Path):
+    ws = _fresh_ws(tmp_path)
+    assert_indexed_build_then_query(
+        SemanticBackend(),
+        default_workspace_factory(ws),
+        location=str(tmp_path / "idx.db"),
+    )
+
+
+def test_build_is_idempotent(tmp_path: Path):
+    ws = _fresh_ws(tmp_path)
+    assert_indexed_build_is_idempotent(
+        SemanticBackend(),
+        default_workspace_factory(ws),
+        location=str(tmp_path / "idx.db"),
+    )
+
+
+def test_handles_deletion(tmp_path: Path):
+    ws = _fresh_ws(tmp_path)
+    assert_indexed_handles_deletion(
+        SemanticBackend(),
+        default_workspace_factory(ws),
+        location=str(tmp_path / "idx.db"),
+    )
+
+
+def test_info_tolerates_missing(tmp_path: Path):
+    assert_indexed_info_tolerates_missing(
+        SemanticBackend(),
+        missing_location=str(tmp_path / "does-not-exist.db"),
+    )
+
+
+def test_version_mismatch_raises(tmp_path: Path):
+    def _corrupt(location: str) -> None:
+        conn = sqlite3.connect(location)
+        try:
+            conn.execute("UPDATE meta SET value='99' WHERE key='format_version'")
+            conn.commit()
+        finally:
+            conn.close()
+
+    ws = _fresh_ws(tmp_path)
+    backend = SemanticBackend()
+    location = str(tmp_path / "idx.db")
+    # Build first so there's something to corrupt.
+    factory = default_workspace_factory(ws)
+    workspace = factory({"a.md": "---\n---\nalpha\n"})
+    backend.build(list(workspace.packets.values()), location)
+    assert_indexed_version_mismatch_raises(backend, _corrupt, location)

--- a/packages/fmql-semantic/tests/test_fusion.py
+++ b/packages/fmql-semantic/tests/test_fusion.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from fmql_semantic.fusion import K_RRF, reciprocal_rank_fusion
+
+
+def test_rrf_known_output():
+    dense = [("a", 0.9), ("b", 0.8), ("c", 0.7)]
+    sparse = [("c", 3.0), ("b", 2.0), ("d", 1.0)]
+    out = reciprocal_rank_fusion(dense, sparse)
+    # Scores (k_rrf=60):
+    # a: 1/61                ≈ 0.01639
+    # b: 1/62 + 1/62         ≈ 0.03226
+    # c: 1/63 + 1/61         ≈ 0.03226
+    # d: 1/63                ≈ 0.01587
+    ids = [pid for pid, _ in out]
+    assert ids[:2] == ["b", "c"] or ids[:2] == ["c", "b"]
+    assert set(ids) == {"a", "b", "c", "d"}
+    score_map = dict(out)
+    assert score_map["b"] == 1 / (K_RRF + 2) + 1 / (K_RRF + 2)
+    assert score_map["a"] == 1 / (K_RRF + 1)
+
+
+def test_rrf_empty_lists():
+    assert reciprocal_rank_fusion([], []) == []
+
+
+def test_rrf_single_list():
+    out = reciprocal_rank_fusion([("a", 1.0), ("b", 0.5)])
+    assert [pid for pid, _ in out] == ["a", "b"]
+
+
+def test_rrf_custom_k():
+    out = reciprocal_rank_fusion([("a", 1.0)], k_rrf=10)
+    assert out[0][1] == 1 / 11

--- a/packages/fmql-semantic/tests/test_import.py
+++ b/packages/fmql-semantic/tests/test_import.py
@@ -1,0 +1,19 @@
+import fmql_semantic
+from fmql_semantic import SemanticBackend
+
+
+def test_version():
+    assert fmql_semantic.__version__
+
+
+def test_backend_exposed():
+    assert SemanticBackend.name == "semantic"
+
+
+def test_entrypoint_discoverable():
+    from fmql.search.registry import clear_cache, discover_backends
+
+    clear_cache()
+    backends = discover_backends()
+    assert "semantic" in backends, f"registered backends: {sorted(backends)}"
+    assert backends["semantic"] is SemanticBackend

--- a/packages/fmql-semantic/tests/test_info.py
+++ b/packages/fmql-semantic/tests/test_info.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fmql.workspace import Workspace
+from fmql_semantic import SemanticBackend
+
+
+@pytest.fixture(autouse=True)
+def _env_model(monkeypatch):
+    monkeypatch.setenv("FMQL_EMBEDDING_MODEL", "fake/embed")
+
+
+def test_info_without_location():
+    info = SemanticBackend().info()
+    assert info.kind == "indexed"
+    assert info.name == "semantic"
+    assert info.version
+
+
+def test_info_missing_file_reports_error(tmp_path: Path):
+    info = SemanticBackend().info(str(tmp_path / "missing.db"))
+    assert info.kind == "indexed"
+    assert info.metadata.get("error")
+
+
+def test_info_reads_meta_from_real_index(tmp_path: Path):
+    root = tmp_path / "ws"
+    root.mkdir()
+    (root / "a.md").write_text("---\n---\nalpha\n", encoding="utf-8")
+    ws = Workspace(root)
+    backend = SemanticBackend()
+    loc = str(tmp_path / "idx.db")
+    backend.build(list(ws.packets.values()), loc)
+    info = backend.info(loc)
+    assert info.metadata["embedding_model"] == "fake/embed"
+    assert info.metadata["embedding_dim"] == "8"
+
+
+def test_default_location_uses_workspace_root(tmp_path: Path):
+    root = tmp_path / "ws"
+    root.mkdir()
+    ws = Workspace(root)
+    be = SemanticBackend()
+    assert be.default_location(ws).endswith(".fmql/semantic.db")
+
+
+def test_parse_location_rejects_empty():
+    with pytest.raises(ValueError):
+        SemanticBackend().parse_location("")

--- a/packages/fmql-semantic/tests/test_query_modes.py
+++ b/packages/fmql-semantic/tests/test_query_modes.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fmql.workspace import Workspace
+from fmql_semantic import SemanticBackend
+
+
+@pytest.fixture(autouse=True)
+def _env_model(monkeypatch):
+    monkeypatch.setenv("FMQL_EMBEDDING_MODEL", "fake/embed")
+
+
+def _ws(root: Path, files: dict[str, str]) -> Workspace:
+    root.mkdir(parents=True, exist_ok=True)
+    for rel, content in files.items():
+        (root / rel).write_text(content, encoding="utf-8")
+    return Workspace(root)
+
+
+def _build(tmp_path: Path) -> tuple[SemanticBackend, str]:
+    ws = _ws(
+        tmp_path / "ws",
+        {
+            "widgets.md": "---\ntitle: Widget spec\n---\nWidgets are small things.\n",
+            "sprockets.md": "---\ntitle: Sprocket design\n---\nSprockets rotate.\n",
+            "other.md": "---\ntitle: Unrelated\n---\nSomething totally different.\n",
+        },
+    )
+    backend = SemanticBackend()
+    loc = str(tmp_path / "idx.db")
+    backend.build(list(ws.packets.values()), loc)
+    return backend, loc
+
+
+def test_hybrid_returns_results(tmp_path: Path):
+    backend, loc = _build(tmp_path)
+    hits = backend.query("widgets", loc, k=3)
+    assert len(hits) >= 1
+    ids = [h.packet_id for h in hits]
+    assert "widgets.md" in ids
+
+
+def test_sparse_only_skips_embeddings(tmp_path: Path, monkeypatch):
+    backend, loc = _build(tmp_path)
+    from fmql_semantic import backend as backend_mod
+
+    calls = {"n": 0}
+    original = backend_mod._embed_batch
+
+    async def _count(*a, **kw):
+        calls["n"] += 1
+        return await original(*a, **kw)
+
+    monkeypatch.setattr(backend_mod, "_embed_batch", _count)
+    hits = backend.query("widgets", loc, k=3, options={"sparse_only": True})
+    assert calls["n"] == 0, "sparse_only must not call embeddings"
+    assert any(h.packet_id == "widgets.md" for h in hits)
+
+
+def test_dense_only_skips_fts(tmp_path: Path):
+    backend, loc = _build(tmp_path)
+    hits = backend.query("widgets", loc, k=3, options={"dense_only": True})
+    assert len(hits) >= 1
+
+
+def test_empty_query_returns_empty(tmp_path: Path):
+    backend, loc = _build(tmp_path)
+    assert backend.query("", loc, k=3) == []
+
+
+def test_rerank_changes_ordering(tmp_path: Path, monkeypatch):
+    backend, loc = _build(tmp_path)
+
+    # With a configured reranker, the ranker's per-doc scores should drive final order.
+    hits = backend.query(
+        "widgets",
+        loc,
+        k=3,
+        options={"reranker_model": "fake/rerank"},
+    )
+    assert len(hits) >= 1
+
+
+def test_no_rerank_skips_reranker(tmp_path: Path, monkeypatch):
+    backend, loc = _build(tmp_path)
+    import litellm  # type: ignore
+
+    calls = {"n": 0}
+    original = litellm.arerank
+
+    async def _count(*a, **kw):
+        calls["n"] += 1
+        return await original(*a, **kw)
+
+    monkeypatch.setattr(litellm, "arerank", _count)
+    backend.query(
+        "widgets",
+        loc,
+        k=3,
+        options={"reranker_model": "fake/rerank", "no_rerank": True},
+    )
+    assert calls["n"] == 0

--- a/packages/fmql-semantic/tests/test_reranker_fallback.py
+++ b/packages/fmql-semantic/tests/test_reranker_fallback.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fakes.provider import FailingReranker
+
+from fmql.search.errors import BackendUnavailableError
+from fmql.workspace import Workspace
+from fmql_semantic import SemanticBackend
+
+
+@pytest.fixture(autouse=True)
+def _env_model(monkeypatch):
+    monkeypatch.setenv("FMQL_EMBEDDING_MODEL", "fake/embed")
+
+
+def _build(tmp_path: Path) -> tuple[SemanticBackend, str]:
+    root = tmp_path / "ws"
+    root.mkdir()
+    (root / "a.md").write_text("---\n---\nalpha\n", encoding="utf-8")
+    (root / "b.md").write_text("---\n---\nbeta\n", encoding="utf-8")
+    ws = Workspace(root)
+    backend = SemanticBackend()
+    loc = str(tmp_path / "idx.db")
+    backend.build(list(ws.packets.values()), loc)
+    return backend, loc
+
+
+def test_rerank_soft_fail_returns_rrf(tmp_path: Path, monkeypatch):
+    backend, loc = _build(tmp_path)
+    import litellm  # type: ignore
+
+    failing = FailingReranker(RuntimeError("provider down"))
+    monkeypatch.setattr(litellm, "arerank", failing)
+
+    hits = backend.query("alpha", loc, k=3, options={"reranker_model": "fake/rerank"})
+    assert failing.calls == 1
+    assert len(hits) >= 1  # still returns something via RRF
+
+
+def test_rerank_required_hard_fails(tmp_path: Path, monkeypatch):
+    backend, loc = _build(tmp_path)
+    import litellm  # type: ignore
+
+    failing = FailingReranker(RuntimeError("provider down"))
+    monkeypatch.setattr(litellm, "arerank", failing)
+
+    with pytest.raises(BackendUnavailableError):
+        backend.query(
+            "alpha",
+            loc,
+            k=3,
+            options={"reranker_model": "fake/rerank", "rerank_required": True},
+        )

--- a/packages/fmql-semantic/tests/test_smoke.py
+++ b/packages/fmql-semantic/tests/test_smoke.py
@@ -1,5 +1,0 @@
-import fmql_semantic
-
-
-def test_import():
-    assert fmql_semantic.__version__ == "0.0.1"

--- a/packages/fmql-semantic/tests/test_storage.py
+++ b/packages/fmql-semantic/tests/test_storage.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from fmql.search.errors import IndexVersionError
+from fmql_semantic.storage import meta as meta_mod
+from fmql_semantic.storage.connection import open_db
+from fmql_semantic.storage.schema import FORMAT_VERSION
+from fmql_semantic.storage.writer import open_for_build
+
+
+def test_open_for_build_creates_all_tables(tmp_path: Path):
+    location = str(tmp_path / "idx.db")
+    conn = open_for_build(
+        location,
+        embedding_model="fake/embed",
+        embedding_dim=8,
+        fields=("title",),
+        force=False,
+        fmql_version="0.2.0",
+    )
+    try:
+        names = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type in ('table','virtual')"
+            )
+        }
+        # packets_fts shadow tables exist too; we care about the logical ones.
+        assert {"meta", "packets"}.issubset(names)
+        # Virtual tables appear as type='table' with a non-empty sql referencing USING.
+        sqls = [
+            row[0]
+            for row in conn.execute(
+                "SELECT sql FROM sqlite_master WHERE name IN ('vectors','packets_fts')"
+            )
+            if row[0]
+        ]
+        assert any("vec0" in (s or "") for s in sqls)
+        assert any("fts5" in (s or "") for s in sqls)
+
+        meta = meta_mod.read_all(conn)
+        assert meta["format_version"] == str(FORMAT_VERSION)
+        assert meta["embedding_model"] == "fake/embed"
+        assert meta["embedding_dim"] == "8"
+        assert meta["fields"] == "title"
+    finally:
+        conn.close()
+
+
+def test_format_version_mismatch_raises_on_read(tmp_path: Path):
+    location = str(tmp_path / "idx.db")
+    conn = open_for_build(
+        location,
+        embedding_model="fake/embed",
+        embedding_dim=8,
+        fields=("title",),
+        force=False,
+        fmql_version="0.2.0",
+    )
+    conn.close()
+
+    raw = sqlite3.connect(location)
+    raw.execute("UPDATE meta SET value='99' WHERE key='format_version'")
+    raw.commit()
+    raw.close()
+
+    conn = open_db(location, readonly=True, load_vec=False)
+    try:
+        meta = meta_mod.read_all(conn)
+        with pytest.raises(IndexVersionError):
+            meta_mod.check_format_version(meta)
+    finally:
+        conn.close()
+
+
+def test_force_rebuild_drops_tables(tmp_path: Path):
+    location = str(tmp_path / "idx.db")
+    # First build with dim=8
+    conn = open_for_build(
+        location,
+        embedding_model="fake/embed",
+        embedding_dim=8,
+        fields=("title",),
+        force=False,
+        fmql_version="0.2.0",
+    )
+    conn.close()
+    # Second build with different model + force=True should succeed.
+    conn = open_for_build(
+        location,
+        embedding_model="other/embed",
+        embedding_dim=16,
+        fields=("title",),
+        force=True,
+        fmql_version="0.2.0",
+    )
+    try:
+        meta = meta_mod.read_all(conn)
+        assert meta["embedding_model"] == "other/embed"
+        assert meta["embedding_dim"] == "16"
+    finally:
+        conn.close()
+
+
+def test_model_pin_refuses_without_force(tmp_path: Path):
+    from fmql.search.errors import BackendUnavailableError
+
+    location = str(tmp_path / "idx.db")
+    conn = open_for_build(
+        location,
+        embedding_model="fake/embed",
+        embedding_dim=8,
+        fields=("title",),
+        force=False,
+        fmql_version="0.2.0",
+    )
+    conn.close()
+    with pytest.raises(BackendUnavailableError, match="fake/embed"):
+        open_for_build(
+            location,
+            embedding_model="other/embed",
+            embedding_dim=8,
+            fields=("title",),
+            force=False,
+            fmql_version="0.2.0",
+        )

--- a/packages/fmql-semantic/tests/test_textprep.py
+++ b/packages/fmql-semantic/tests/test_textprep.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fmql.workspace import Workspace
+from fmql_semantic.textprep import (
+    build_document,
+    build_rows,
+    content_hash,
+    pick_frontmatter_field,
+)
+
+
+def _ws(tmp_path: Path, files: dict[str, str]) -> Workspace:
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    return Workspace(tmp_path)
+
+
+def test_pick_first_present_field(tmp_path: Path):
+    ws = _ws(
+        tmp_path,
+        {
+            "a.md": "---\ntitle: Hello\nsummary: ignore\n---\nBody.\n",
+            "b.md": "---\nsummary: Fallback\n---\nBody.\n",
+            "c.md": "---\nname: Last resort\n---\nBody.\n",
+            "d.md": "---\n---\nBody.\n",
+        },
+    )
+    field, value = pick_frontmatter_field(ws.packets["a.md"], ("title", "summary", "name"))
+    assert (field, value) == ("title", "Hello")
+    field, value = pick_frontmatter_field(ws.packets["b.md"], ("title", "summary", "name"))
+    assert (field, value) == ("summary", "Fallback")
+    field, value = pick_frontmatter_field(ws.packets["c.md"], ("title", "summary", "name"))
+    assert (field, value) == ("name", "Last resort")
+    field, value = pick_frontmatter_field(ws.packets["d.md"], ("title", "summary", "name"))
+    assert (field, value) == (None, None)
+
+
+def test_build_document_concatenates(tmp_path: Path):
+    ws = _ws(tmp_path, {"a.md": "---\ntitle: Hello\n---\nBody text.\n"})
+    doc, truncated = build_document(ws.packets["a.md"], ("title",), max_tokens=100)
+    assert "Hello" in doc and "Body text." in doc
+    assert truncated is False
+
+
+def test_truncation_flag(tmp_path: Path):
+    long_body = "x" * 10_000
+    ws = _ws(tmp_path, {"a.md": f"---\ntitle: T\n---\n{long_body}\n"})
+    doc, truncated = build_document(ws.packets["a.md"], ("title",), max_tokens=100)
+    assert truncated is True
+    assert len(doc) <= 100 * 4
+
+
+def test_hash_stable_across_calls(tmp_path: Path):
+    ws = _ws(tmp_path, {"a.md": "---\ntitle: Hello\n---\nBody.\n"})
+    h1 = content_hash(ws.packets["a.md"], ("title",), max_tokens=100)
+    h2 = content_hash(ws.packets["a.md"], ("title",), max_tokens=100)
+    assert h1 == h2
+
+
+def test_hash_changes_on_body_edit(tmp_path: Path):
+    ws1 = _ws(tmp_path, {"a.md": "---\ntitle: Hello\n---\nBody v1.\n"})
+    h1 = content_hash(ws1.packets["a.md"], ("title",), max_tokens=100)
+    ws2 = _ws(tmp_path, {"a.md": "---\ntitle: Hello\n---\nBody v2.\n"})
+    h2 = content_hash(ws2.packets["a.md"], ("title",), max_tokens=100)
+    assert h1 != h2
+
+
+def test_build_rows_warns_once(tmp_path: Path, recwarn):
+    long = "x" * 10_000
+    ws = _ws(
+        tmp_path,
+        {
+            "a.md": f"---\ntitle: A\n---\n{long}\n",
+            "b.md": f"---\ntitle: B\n---\n{long}\n",
+        },
+    )
+    rows = list(build_rows(ws.packets.values(), ("title",), max_tokens=100))
+    assert len(rows) == 2
+    truncation_warnings = [w for w in recwarn.list if "truncated" in str(w.message)]
+    assert len(truncation_warnings) == 1


### PR DESCRIPTION
## Summary

- Fills in the `packages/fmql-semantic/` slot with a hybrid-retrieval backend registered via the `fmql.search_index` entry point.
- Dense embeddings (LiteLLM + `sqlite-vec`) + sparse BM25 (SQLite FTS5) fused via RRF, with optional cross-encoder reranking that soft-fails to RRF.
- Incremental indexing keyed on content hash; model + format-version pinned in index metadata with `--force` escape hatch.
- Config flows through `--option KEY=VALUE` (plus `FMQL_*` env and dotenv via `--option env=path`) — zero changes to fmql core.

## Test plan

- [x] `uv run pytest packages/fmql-semantic/tests/ -v` — 54/54 pass
- [x] `uv run pytest packages/fmql/tests/` — 326/326 still green (core untouched)
- [x] `uv run ruff check packages/fmql-semantic` — clean
- [x] `uv run black --check packages/fmql-semantic` — clean
- [x] `uv run fmql list-backends` — shows `semantic indexed 0.0.1` alongside `grep`
- [x] `uv build --package fmql-semantic` — wheel builds; `fmql.search_index` entry point present in `entry_points.txt`
- [x] End-to-end smoke with a real embedding provider (requires API key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)