### PR TITLE
fmql-semantic: publish dotenv keys to os.environ for LiteLLM

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,11 +4,10 @@
 - Allow string / number literals as `RETURN` items (e.g. `RETURN a.title, "|", b.title`).
 - Visible row separator in `rows` format (tab is invisible); `--separator` option or better default.
 - All file paths in the CLI should be workspace-relative, everywhere (positional args, stdin, outputs).
-- `fmql-semantic`: `--option env=.env` only loads `FMQL_*` keys; provider vars like `AZURE_API_BASE`, `AZURE_API_KEY`, `AZURE_API_VERSION`, `OPENAI_API_KEY` are silently ignored. LiteLLM reads them from `os.environ` directly, so users expecting a general dotenv loader hit confusing auth/connection errors. Fix: either push all parsed .env vars into `os.environ` so LiteLLM picks them up, or document the `FMQL_*`-only scope explicitly.
 - `fmql-semantic`: remove the "Python build must support loadable-extension sqlite3" install requirement. `pysqlite3-binary` (ChromaDB's solution) does NOT solve this on macOS because there are no macOS wheels for it; rules out the `sys.modules` swap approach. Use **apsw** instead: pre-built wheels for macOS (x86_64 + arm64), Linux, Windows, always supports `enable_load_extension()` regardless of system Python build flags. Requires a compatibility shim in fmql-semantic because apsw's API (cursors, exceptions, parameter binding) is not drop-in with stdlib sqlite3. Ship a thin wrapper that exposes the subset fmql-semantic uses, and swap the backend import. Result: `pip install fmql-semantic` works on any Python, on any platform, and the README can drop its Python-build caveat entirely.
 
 - [ ] fmql-semantic (not a blocker): that LiteLLM RuntimeWarning at the end of every indexing run is user-visible noise. Two ways to clean it up — either bump the pinned LiteLLM version (newer versions have fixed some of these async-logging paths) or suppress it explicitly around the embedding call
-  
+
 
 ## Wishlist
 

--- a/packages/fmql-semantic/CHANGELOG.md
+++ b/packages/fmql-semantic/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this package will be documented in this file.
 
+## Unreleased
+
+### Changed
+
+- `--option env=PATH` now publishes every key from the dotenv file to `os.environ` (via `setdefault`) so LiteLLM provider credentials (`OPENAI_API_KEY`, `AZURE_API_*`, …) are picked up. `FMQL_*` keys still drive the typed config; existing shell env vars are never overridden.
+
 ## [0.1.0] - 2026-04-17
 
 ### Added

--- a/packages/fmql-semantic/README.md
+++ b/packages/fmql-semantic/README.md
@@ -93,7 +93,11 @@ precedence:
 | `FMQL_RERANKER_TOP_N` | Candidates sent to reranker (default 50). |
 
 Standard LiteLLM provider env vars (`OPENAI_API_KEY`, `VOYAGE_API_KEY`,
-`OLLAMA_API_BASE`, …) are read by LiteLLM directly.
+`OLLAMA_API_BASE`, …) are read by LiteLLM directly from the process
+environment. A dotenv file passed via `--option env=path/to/.env` also
+publishes its non-`FMQL_*` keys into `os.environ` (without overriding
+values already exported by the shell), so the same file can carry both
+`FMQL_*` settings and provider credentials.
 
 ### `--option` keys
 

--- a/packages/fmql-semantic/src/fmql_semantic/config.py
+++ b/packages/fmql-semantic/src/fmql_semantic/config.py
@@ -153,6 +153,8 @@ def resolve_config(options: dict | None, *, kind: Literal["build", "query"]) -> 
         for env_key, field in _ENV_MAP.items():
             if env_key in parsed:
                 layered[field] = _coerce(field, parsed[env_key])
+        for key, value in parsed.items():
+            os.environ.setdefault(key, value)
 
     for opt_key, value in options.items():
         field = _OPT_MAP[opt_key]

--- a/packages/fmql-semantic/tests/test_config.py
+++ b/packages/fmql-semantic/tests/test_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -39,6 +40,33 @@ def test_dotenv_layered_between_env_and_options(monkeypatch, tmp_path: Path):
 def test_missing_dotenv_errors():
     with pytest.raises(ConfigError, match="dotenv file not found"):
         resolve_config({"env": "/nonexistent/file.env"}, kind="build")
+
+
+@pytest.fixture
+def env_snapshot():
+    saved = dict(os.environ)
+    yield
+    for key in list(os.environ):
+        if key not in saved:
+            del os.environ[key]
+    for key, value in saved.items():
+        os.environ[key] = value
+
+
+def test_dotenv_publishes_provider_vars_to_environ(env_snapshot, tmp_path: Path):
+    os.environ.pop("OPENAI_API_KEY", None)
+    env_file = tmp_path / ".env"
+    env_file.write_text("FMQL_EMBEDDING_MODEL=m\nOPENAI_API_KEY=foo\n")
+    resolve_config({"env": str(env_file)}, kind="build")
+    assert os.environ["OPENAI_API_KEY"] == "foo"
+
+
+def test_dotenv_does_not_override_existing_environ(env_snapshot, tmp_path: Path):
+    os.environ["OPENAI_API_KEY"] = "shell"
+    env_file = tmp_path / ".env"
+    env_file.write_text("FMQL_EMBEDDING_MODEL=m\nOPENAI_API_KEY=dotenv\n")
+    resolve_config({"env": str(env_file)}, kind="build")
+    assert os.environ["OPENAI_API_KEY"] == "shell"
 
 
 def test_unknown_option_for_build():


### PR DESCRIPTION
## Summary

- `--option env=PATH` previously only consumed `FMQL_*` keys; provider credentials like `OPENAI_API_KEY`, `AZURE_API_BASE`, `AZURE_API_KEY`, `AZURE_API_VERSION` placed in the same `.env` were silently dropped, causing confusing LiteLLM auth/connection errors.
- After parsing the dotenv, every key is now published to `os.environ` via `os.environ.setdefault(...)`. `FMQL_*` keys still drive the typed `Config`; shell-exported values are never overridden (matches python-dotenv's default `override=False`).
- README and CHANGELOG updated; two new tests (`test_dotenv_publishes_provider_vars_to_environ`, `test_dotenv_does_not_override_existing_environ`) plus an `env_snapshot` fixture that restores `os.environ` because `monkeypatch` can't track mutations made by the code under test.

## Test plan

- [x] `cd packages/fmql-semantic && uv run pytest tests/test_config.py -q` — 16 passed
- [x] `cd packages/fmql-semantic && uv run pytest -q` — full suite green
- [x] Manual smoke with a real `.env` containing `FMQL_EMBEDDING_MODEL` + `OPENAI_API_KEY`, `unset OPENAI_API_KEY`, and run `fmql index ... --option env=...` — build should succeed without auth errors
- [x] Precedence check: with `OPENAI_API_KEY=shell-val` exported and a different value in `.env`, confirm the shell value is the one LiteLLM uses

🤖 Generated with [Claude Code](https://claude.com/claude-code)