### PR TITLE
fmql-semantic: suppress benign LiteLLM unawaited-coroutine RuntimeWarning

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,8 @@
 # TODO
 
 - [ ] All file paths in the CLI should be workspace-relative, everywhere (positional args, stdin, outputs).
-  
-- [ ] `fmql-semantic`: remove the "Python build must support loadable-extension sqlite3" install requirement. `pysqlite3-binary` (ChromaDB's solution) does NOT solve this on macOS because there are no macOS wheels for it; rules out the `sys.modules` swap approach. Use **apsw** instead: pre-built wheels for macOS (x86_64 + arm64), Linux, Windows, always supports `enable_load_extension()` regardless of system Python build flags. Requires a compatibility shim in fmql-semantic because apsw's API (cursors, exceptions, parameter binding) is not drop-in with stdlib sqlite3. Ship a thin wrapper that exposes the subset fmql-semantic uses, and swap the backend import. Result: `pip install fmql-semantic` works on any Python, on any platform, and the README can drop its Python-build caveat entirely.
 
-- [ ] fmql-semantic (not a blocker): that LiteLLM RuntimeWarning at the end of every indexing run is user-visible noise. Two ways to clean it up — either bump the pinned LiteLLM version (newer versions have fixed some of these async-logging paths) or suppress it explicitly around the embedding call
+- [ ] `fmql-semantic`: remove the "Python build must support loadable-extension sqlite3" install requirement. `pysqlite3-binary` (ChromaDB's solution) does NOT solve this on macOS because there are no macOS wheels for it; rules out the `sys.modules` swap approach. Use **apsw** instead: pre-built wheels for macOS (x86_64 + arm64), Linux, Windows, always supports `enable_load_extension()` regardless of system Python build flags. Requires a compatibility shim in fmql-semantic because apsw's API (cursors, exceptions, parameter binding) is not drop-in with stdlib sqlite3. Ship a thin wrapper that exposes the subset fmql-semantic uses, and swap the backend import. Result: `pip install fmql-semantic` works on any Python, on any platform, and the README can drop its Python-build caveat entirely.
 
 
 ## Wishlist
@@ -12,3 +10,5 @@
 - [ ] Pattern matching for inferring document type from its structure
 - [ ] filesystem level operations (inspecting filesystem metadata, filesystem ops: mv, cp, rm, ls, etc...)
 - [ ] Filesystem level operations could automatically doctor links when files move around or are deleted.
+
+

--- a/packages/fmql-semantic/src/fmql_semantic/embeddings.py
+++ b/packages/fmql-semantic/src/fmql_semantic/embeddings.py
@@ -1,10 +1,21 @@
 from __future__ import annotations
 
 import asyncio
+import warnings
 from typing import Sequence
 
 from fmql.search.errors import BackendUnavailableError
 from fmql_semantic.config import Config
+
+# LiteLLM's LoggingWorker schedules an async success handler from a sync code
+# path; the coroutine is GC'd unawaited when our event loop closes, producing a
+# benign RuntimeWarning on every indexing run. Silence that one message only.
+warnings.filterwarnings(
+    "ignore",
+    message=r"coroutine 'Logging\.async_success_handler' was never awaited",
+    category=RuntimeWarning,
+    module=r"litellm.*",
+)
 
 
 async def _embed_batch(


### PR DESCRIPTION
## Summary

- `fmql index --backend semantic` was printing a `RuntimeWarning: coroutine 'Logging.async_success_handler' was never awaited` at the end of every run — noise originating from LiteLLM's internal `LoggingWorker`, not our code.
- Register a narrow `warnings.filterwarnings(...)` in [embeddings.py](packages/fmql-semantic/src/fmql_semantic/embeddings.py) scoped by category (`RuntimeWarning`), message pattern (the specific coroutine name), and originating module (`litellm.*`) so unrelated warnings are untouched.
- Drops the corresponding entry from [TODO.md](TODO.md).

## Test plan

- [x] `make format`
- [x] `make lint`
- [x] `make test` (375 + 56 passing)
- [ ] Manual: run `fmql index --backend semantic <backlog>` and confirm the RuntimeWarning is gone while the `indexed N packet(s)` / timing summary still prints
- [ ] Manual: run `fmql search --backend semantic <query> <backlog>` and confirm query path is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)