### PR TITLE
Release fmql 0.2.2 + fmql-semantic 0.1.1

### DIFF
--- a/packages/fmql-semantic/CHANGELOG.md
+++ b/packages/fmql-semantic/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 All notable changes to this package will be documented in this file.
 
-## Unreleased
+## [0.1.1] - 2026-04-21
 
 ### Changed
 
 - `--option env=PATH` now publishes every key from the dotenv file to `os.environ` (via `setdefault`) so LiteLLM provider credentials (`OPENAI_API_KEY`, `AZURE_API_*`, …) are picked up. `FMQL_*` keys still drive the typed config; existing shell env vars are never overridden.
+
+### Fixed
+
+- Suppress a benign `RuntimeWarning: coroutine '…' was never awaited` emitted at interpreter shutdown by LiteLLM's `LoggingWorker`. A narrow `warnings.filterwarnings` entry (matched by message, category, and originating module) silences the noise without masking unrelated warnings.
 
 ## [0.1.0] - 2026-04-17
 

--- a/packages/fmql-semantic/pyproject.toml
+++ b/packages/fmql-semantic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fmql-semantic"
-version = "0.1.0"
+version = "0.1.1"
 description = "Semantic (hybrid dense + sparse) search backend plugin for fmql."
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/fmql/CHANGELOG.md
+++ b/packages/fmql/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.2] - 2026-04-21
+
+### Added
+
+- `fmql subgraph WORKSPACE SEED_QUERY --follow FIELD [...]` command: returns the reachability closure around seed packets as `{nodes, edges}` JSON. Supports `--depth N|'*'` (default: full closure), `--direction {forward,reverse}`, `--resolver {path,uuid,slug}`, `--include-origin/--no-include-origin`, and `--ids-only`.
+- `fmql subgraph --format {raw,cytoscape}` flag. `raw` (default) preserves the `{nodes, edges}` shape; `cytoscape` emits `{elements: {nodes, edges}}` with Cytoscape.js-compatible `data` wrappers and synthesized edge IDs (`source__field__target`), ready for `cy.add()` / `cytoscape({elements: …})`.
+- Resolver-mismatch diagnostic: when traversal (on `query`, `cypher`, or `subgraph`) returns zero edges from seeds that do have reference fields, a hint is emitted to stderr pointing at likely resolver misconfiguration (e.g. UUID-style refs with the default `path` resolver).
+
 ## [0.2.1]
 
 ### Added

--- a/packages/fmql/README.md
+++ b/packages/fmql/README.md
@@ -93,6 +93,7 @@ Official plugins live alongside core in the [fmql monorepo](https://github.com/b
 | `toggle` | Toggle boolean fields | `fmql toggle ./tasks/task-42.md flagged` |
 | `describe` | Workspace introspection | `fmql describe ./project` |
 | `cypher` | Graph pattern query (Cypher subset) | `fmql cypher ./project 'MATCH (a)-[:blocked_by]->(b) RETURN a, b'` |
+| `subgraph` | Reachability closure around seed packets as `{nodes, edges}` JSON | `fmql subgraph ./project 'uuid = "task-1"' --follow blocked_by` |
 | `search` | Run a search backend against a workspace/index | `fmql search 'alice' --workspace ./project` |
 | `index` | Build an index for an indexed backend | `fmql index ./project --backend semantic --out ./project/.fmql/semantic` |
 | `list-backends` | Enumerate discovered search backends | `fmql list-backends` |
@@ -100,8 +101,9 @@ Official plugins live alongside core in the [fmql monorepo](https://github.com/b
 Common flags:
 
 - `--format {paths,json,rows}` — output format (default: `paths` for `query`, `rows` for `cypher`).
-- `--follow FIELD`, `--depth N|'*'`, `--direction {forward,reverse}` — traversal on `query`.
-- `--resolver {path,uuid,slug}` — reference resolution strategy for traversal/Cypher.
+- `--follow FIELD`, `--depth N|'*'`, `--direction {forward,reverse}` — traversal on `query` and `subgraph`.
+- `--resolver {path,uuid,slug}` — reference resolution strategy for traversal/Cypher/subgraph.
+- `--format {raw,cytoscape}` — output shape for `subgraph` (default `raw`).
 - `--search QUERY`, `--index NAME`, `--index-location LOCATION` — pluggable search stage (backend default: `grep`).
 - `--dry-run`, `--yes` — preview or auto-confirm for edit commands.
 - `--workspace ROOT` — explicit workspace root when piping paths into edit commands.
@@ -248,6 +250,17 @@ References in frontmatter fields are resolved by the selected resolver:
 - `slug` — matches a `slug` frontmatter field on other packets.
 
 Pass `--resolver uuid` / `--resolver slug` to switch. Unresolvable references are dropped silently.
+
+For the whole reachability closure as structured graph data (not a row set), use `fmql subgraph`. It emits `{nodes, edges}` JSON by default (`--format raw`), or a Cytoscape.js-ready shape with `--format cytoscape`:
+
+```bash
+# Default: {nodes, edges} for jq / custom pipelines
+fmql subgraph ./project 'status = "active"' --follow blocked_by
+
+# Cytoscape.js: {elements: {nodes, edges}} with data wrappers + synthesized edge IDs,
+# ready for cy.add(…) or cytoscape({elements: …})
+fmql subgraph ./project 'status = "active"' --follow blocked_by --format cytoscape > graph.json
+```
 
 ## Aggregation & describe
 

--- a/packages/fmql/pyproject.toml
+++ b/packages/fmql/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fmql"
-version = "0.2.1"
+version = "0.2.2"
 description = "A schemaless query engine and editor for directories of frontmatter files."
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/fmql/src/fmql/cli/cmd_cypher.py
+++ b/packages/fmql/src/fmql/cli/cmd_cypher.py
@@ -12,20 +12,13 @@ from fmql.cypher import compile_cypher_ast, parse_cypher
 from fmql.diagnostics import emit_resolver_mismatch_hints
 from fmql.errors import FmqlError
 from fmql.resolvers import resolver_by_name
+from fmql.serialization import json_default
 from fmql.workspace import Workspace
 
 
 class CypherFormat(str, Enum):
     rows = "rows"
     json = "json"
-
-
-def _json_default(o):
-    if isinstance(o, datetime):
-        return o.isoformat()
-    if isinstance(o, date):
-        return o.isoformat()
-    raise TypeError(f"not JSON-serializable: {type(o).__name__}")
 
 
 def _format_cell(v):
@@ -72,7 +65,7 @@ def cypher_cmd(
             cols = list(result.columns)
             for row in result.rows:
                 payload = {"columns": cols, "row": list(row)}
-                typer.echo(json.dumps(payload, default=_json_default, ensure_ascii=False))
+                typer.echo(json.dumps(payload, default=json_default, ensure_ascii=False))
 
     if not result.is_scalar and not result.rows:
         emit_resolver_mismatch_hints(ws, (rel.field for rel in ast.pattern.rels))

--- a/packages/fmql/src/fmql/cli/cmd_query.py
+++ b/packages/fmql/src/fmql/cli/cmd_query.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from datetime import date, datetime
 from enum import Enum
 from pathlib import Path
 from typing import Optional, Union
@@ -12,6 +11,7 @@ from fmql.diagnostics import emit_resolver_mismatch_hints
 from fmql.errors import FmqlError
 from fmql.qlang import compile_query
 from fmql.resolvers import resolver_by_name
+from fmql.serialization import json_default
 from fmql.workspace import Workspace
 
 
@@ -23,14 +23,6 @@ class OutputFormat(str, Enum):
 class Direction(str, Enum):
     forward = "forward"
     reverse = "reverse"
-
-
-def _json_default(o):
-    if isinstance(o, datetime):
-        return o.isoformat()
-    if isinstance(o, date):
-        return o.isoformat()
-    raise TypeError(f"not JSON-serializable: {type(o).__name__}")
 
 
 def _parse_depth(depth: str) -> Union[int, str]:
@@ -97,7 +89,7 @@ def query_cmd(
     else:
         for packet in packets:
             payload = {"id": packet.id, "frontmatter": packet.as_plain()}
-            typer.echo(json.dumps(payload, default=_json_default, ensure_ascii=False))
+            typer.echo(json.dumps(payload, default=json_default, ensure_ascii=False))
 
     if follow is not None and not packets and seeds_q.ids():
         r = resolver_by_name(resolver) if resolver else None

--- a/packages/fmql/src/fmql/cli/cmd_subgraph.py
+++ b/packages/fmql/src/fmql/cli/cmd_subgraph.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from datetime import date, datetime
 from enum import Enum
 from pathlib import Path
 from typing import List, Optional, Union
@@ -12,21 +11,15 @@ from fmql.diagnostics import emit_resolver_mismatch_hints
 from fmql.errors import FmqlError
 from fmql.qlang import compile_query
 from fmql.resolvers import resolver_by_name
+from fmql.serialization import json_default
 from fmql.subgraph import collect_subgraph
+from fmql.subgraph_formats import SubgraphFormat, format_subgraph
 from fmql.workspace import Workspace
 
 
 class Direction(str, Enum):
     forward = "forward"
     reverse = "reverse"
-
-
-def _json_default(o):
-    if isinstance(o, datetime):
-        return o.isoformat()
-    if isinstance(o, date):
-        return o.isoformat()
-    raise TypeError(f"not JSON-serializable: {type(o).__name__}")
 
 
 def _parse_depth(depth: str) -> Union[int, str]:
@@ -66,6 +59,11 @@ def subgraph_cmd(
     ids_only: bool = typer.Option(
         False, "--ids-only", help="Emit nodes as ids only (omit frontmatter)."
     ),
+    fmt: SubgraphFormat = typer.Option(
+        SubgraphFormat.raw,
+        "--format",
+        help="Output format: raw (default) | cytoscape.",
+    ),
 ) -> None:
     try:
         ws = Workspace(path)
@@ -93,13 +91,8 @@ def subgraph_cmd(
             packet = ws.packets.get(pid)
             nodes_payload.append({"id": pid, "frontmatter": packet.as_plain() if packet else {}})
     edges_payload = [{"source": e.source, "target": e.target, "field": e.field} for e in sg.edges]
-    typer.echo(
-        json.dumps(
-            {"nodes": nodes_payload, "edges": edges_payload},
-            default=_json_default,
-            ensure_ascii=False,
-        )
-    )
+    output = format_subgraph({"nodes": nodes_payload, "edges": edges_payload}, fmt)
+    typer.echo(json.dumps(output, default=json_default, ensure_ascii=False))
 
     if not sg.edges and seeds:
         emit_resolver_mismatch_hints(ws, fields, resolver=r)

--- a/packages/fmql/src/fmql/describe.py
+++ b/packages/fmql/src/fmql/describe.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from fmql.filters import type_name
+from fmql.serialization import json_default
 from fmql.workspace import Workspace
 
 
@@ -134,16 +135,6 @@ def format_text(stats: WorkspaceStats) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _json_default(o: Any) -> Any:
-    if isinstance(o, datetime):
-        return o.isoformat()
-    if isinstance(o, date):
-        return o.isoformat()
-    if isinstance(o, Path):
-        return str(o)
-    raise TypeError(f"not JSON-serializable: {type(o).__name__}")
-
-
 def format_json(stats: WorkspaceStats) -> str:
     payload = {
         "root": str(stats.root),
@@ -164,4 +155,4 @@ def format_json(stats: WorkspaceStats) -> str:
             for s in stats.fields
         ],
     }
-    return json.dumps(payload, default=_json_default, ensure_ascii=False, indent=2)
+    return json.dumps(payload, default=json_default, ensure_ascii=False, indent=2)

--- a/packages/fmql/src/fmql/serialization.py
+++ b/packages/fmql/src/fmql/serialization.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any
+
+
+def json_default(o: Any) -> Any:
+    if isinstance(o, datetime):
+        return o.isoformat()
+    if isinstance(o, date):
+        return o.isoformat()
+    if isinstance(o, Path):
+        return str(o)
+    raise TypeError(f"not JSON-serializable: {type(o).__name__}")

--- a/packages/fmql/src/fmql/subgraph_formats.py
+++ b/packages/fmql/src/fmql/subgraph_formats.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Callable
+
+Payload = dict[str, Any]
+
+
+class SubgraphFormat(str, Enum):
+    raw = "raw"
+    cytoscape = "cytoscape"
+
+
+def _raw(payload: Payload) -> Payload:
+    return payload
+
+
+def _cytoscape(payload: Payload) -> Payload:
+    nodes = [{"data": n} for n in payload["nodes"]]
+    edges = [
+        {"data": {**e, "id": f"{e['source']}__{e['field']}__{e['target']}"}}
+        for e in payload["edges"]
+    ]
+    return {"elements": {"nodes": nodes, "edges": edges}}
+
+
+FORMATTERS: dict[SubgraphFormat, Callable[[Payload], Payload]] = {
+    SubgraphFormat.raw: _raw,
+    SubgraphFormat.cytoscape: _cytoscape,
+}
+
+
+def format_subgraph(payload: Payload, fmt: SubgraphFormat) -> Payload:
+    return FORMATTERS[fmt](payload)

--- a/packages/fmql/tests/cli/test_subgraph_cmd.py
+++ b/packages/fmql/tests/cli/test_subgraph_cmd.py
@@ -173,3 +173,96 @@ def test_subgraph_invalid_depth_exits_2(tmp_path: Path):
         ],
     )
     assert result.exit_code == 2
+
+
+def test_subgraph_format_cytoscape(tmp_path: Path):
+    _write_blocked_ws(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "subgraph",
+            str(tmp_path),
+            'uuid = "c"',
+            "--follow",
+            "blocked_by",
+            "--resolver",
+            "uuid",
+            "--format",
+            "cytoscape",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout.strip())
+    assert set(payload.keys()) == {"elements"}
+    assert set(payload["elements"].keys()) == {"nodes", "edges"}
+    node_ids = sorted(n["data"]["id"] for n in payload["elements"]["nodes"])
+    assert node_ids == ["a.md", "b.md", "c.md"]
+    edge_ids = {e["data"]["id"] for e in payload["elements"]["edges"]}
+    assert "c.md__blocked_by__b.md" in edge_ids
+    assert "b.md__blocked_by__a.md" in edge_ids
+    for n in payload["elements"]["nodes"]:
+        assert "frontmatter" in n["data"]
+
+
+def test_subgraph_format_cytoscape_ids_only(tmp_path: Path):
+    _write_blocked_ws(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "subgraph",
+            str(tmp_path),
+            'uuid = "c"',
+            "--follow",
+            "blocked_by",
+            "--resolver",
+            "uuid",
+            "--format",
+            "cytoscape",
+            "--ids-only",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout.strip())
+    for n in payload["elements"]["nodes"]:
+        assert set(n["data"].keys()) == {"id"}
+
+
+def test_subgraph_format_raw_matches_default(tmp_path: Path):
+    _write_blocked_ws(tmp_path)
+    runner = CliRunner()
+    args = [
+        "subgraph",
+        str(tmp_path),
+        'uuid = "c"',
+        "--follow",
+        "blocked_by",
+        "--resolver",
+        "uuid",
+    ]
+    default_result = runner.invoke(app, args)
+    raw_result = runner.invoke(app, [*args, "--format", "raw"])
+    assert default_result.exit_code == 0
+    assert raw_result.exit_code == 0
+    assert json.loads(default_result.stdout) == json.loads(raw_result.stdout)
+
+
+def test_subgraph_format_unknown_exits_2(tmp_path: Path):
+    _write_blocked_ws(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "subgraph",
+            str(tmp_path),
+            'uuid = "c"',
+            "--follow",
+            "blocked_by",
+            "--resolver",
+            "uuid",
+            "--format",
+            "graphviz",
+        ],
+    )
+    assert result.exit_code == 2

--- a/packages/fmql/tests/test_subgraph_formats.py
+++ b/packages/fmql/tests/test_subgraph_formats.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from fmql.subgraph_formats import SubgraphFormat, format_subgraph
+
+
+def _sample() -> dict:
+    return {
+        "nodes": [
+            {"id": "a.md", "frontmatter": {"title": "A"}},
+            {"id": "b.md", "frontmatter": {"title": "B", "blocked_by": "a"}},
+        ],
+        "edges": [
+            {"source": "b.md", "target": "a.md", "field": "blocked_by"},
+        ],
+    }
+
+
+def test_raw_is_identity():
+    payload = _sample()
+    assert format_subgraph(payload, SubgraphFormat.raw) is payload
+
+
+def test_cytoscape_wraps_nodes_in_data():
+    payload = _sample()
+    out = format_subgraph(payload, SubgraphFormat.cytoscape)
+    assert out == {
+        "elements": {
+            "nodes": [
+                {"data": {"id": "a.md", "frontmatter": {"title": "A"}}},
+                {"data": {"id": "b.md", "frontmatter": {"title": "B", "blocked_by": "a"}}},
+            ],
+            "edges": [
+                {
+                    "data": {
+                        "id": "b.md__blocked_by__a.md",
+                        "source": "b.md",
+                        "target": "a.md",
+                        "field": "blocked_by",
+                    }
+                }
+            ],
+        }
+    }
+
+
+def test_cytoscape_with_ids_only_nodes():
+    payload = {
+        "nodes": [{"id": "a.md"}, {"id": "b.md"}],
+        "edges": [{"source": "b.md", "target": "a.md", "field": "blocked_by"}],
+    }
+    out = format_subgraph(payload, SubgraphFormat.cytoscape)
+    assert out["elements"]["nodes"] == [
+        {"data": {"id": "a.md"}},
+        {"data": {"id": "b.md"}},
+    ]
+
+
+def test_cytoscape_synthesizes_edge_ids():
+    payload = {
+        "nodes": [{"id": "x"}, {"id": "y"}],
+        "edges": [
+            {"source": "x", "target": "y", "field": "ref"},
+            {"source": "x", "target": "y", "field": "other"},
+        ],
+    }
+    out = format_subgraph(payload, SubgraphFormat.cytoscape)
+    ids = [e["data"]["id"] for e in out["elements"]["edges"]]
+    assert ids == ["x__ref__y", "x__other__y"]
+
+
+def test_empty_payload_roundtrips_in_both_formats():
+    empty = {"nodes": [], "edges": []}
+    assert format_subgraph(empty, SubgraphFormat.raw) == empty
+    assert format_subgraph(empty, SubgraphFormat.cytoscape) == {
+        "elements": {"nodes": [], "edges": []}
+    }
+
+
+def test_cytoscape_does_not_mutate_input():
+    payload = _sample()
+    before_nodes = [dict(n) for n in payload["nodes"]]
+    before_edges = [dict(e) for e in payload["edges"]]
+    format_subgraph(payload, SubgraphFormat.cytoscape)
+    assert payload["nodes"] == before_nodes
+    assert payload["edges"] == before_edges


### PR DESCRIPTION
## Summary

Cuts **fmql 0.2.2** and **fmql-semantic 0.1.1**.

### fmql 0.2.2

- **`fmql subgraph --format {raw,cytoscape}`** — new flag on the in-flight `subgraph` command. `raw` (default) keeps the current `{nodes, edges}` shape for scripting; `cytoscape` emits `{elements: {nodes, edges}}` with `data` wrappers and synthesized `source__field__target` edge IDs, ready for `cy.add()` / `cytoscape({elements: …})`.
- **README**: `subgraph` documented in the commands table + common-flags list, with a short traversal-section example showing both `--format raw` and `--format cytoscape`.
- **Refactor**: extracted the `_json_default` helper duplicated across `cmd_query`, `cmd_cypher`, `cmd_subgraph`, and `describe` into a single shared `fmql.serialization.json_default` (unified on the superset version that also handles `Path`).
- CHANGELOG entry formalized for the command itself, the `--format` flag, and the resolver-mismatch diagnostic.

### fmql-semantic 0.1.1

- CHANGELOG entries formalized for the two already-merged PRs on this release:
  - env-publish for LiteLLM provider credentials (#6)
  - benign LiteLLM `RuntimeWarning` suppression at shutdown (#11)

## Test plan

- [x] `make format && make lint && make test` — green (385 fmql tests + 56 fmql-semantic tests)
- [x] Smoke `fmql subgraph ./vault '*' --follow blocked_by --format cytoscape` end-to-end
- [x] Spot-check `fmql query --format json` and `fmql cypher --format json` still serialize dates/paths correctly after the `json_default` refactor
- [x] Tag `core-v0.2.2` and `semantic-v0.1.1` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)